### PR TITLE
[Fix] v-modelを用いて入力フォームを双方向バインディングし、データの整合性を取れるように修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,28 +176,16 @@
                     <v-expansion-panel>
                       <v-expansion-panel-header>特定の席に固定する</v-expansion-panel-header>
                       <v-expansion-panel-content>
-                        <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
-                        <div>
+                        <!-- 生徒の入力フォーム -->
+                        <div v-for="(fixCondition, fixIndex) in fixConditions">
                           <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setFixConditionOption1"></v-select>
+                          v-model="fixConditions[fixIndex][0]"></v-select>
                           を、前から
                           <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="setFixConditionOption2"></v-select>
+                          v-model="fixConditions[fixIndex][1]"></v-select>
                           列目、左から
                           <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addFixConditions"></v-select>
-                          列目に固定する
-                        </div>
-                        <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
-                        <div v-for="fixCondition in fixConditions">
-                          <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setFixConditionOption1"></v-select>
-                          を、前から
-                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="setFixConditionOption2"></v-select>
-                          列目、左から
-                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addFixConditions"></v-select>
+                          v-model="fixConditions[fixIndex][2]" @change.once="createNewFixConditions"></v-select>
                           列目に固定する
                         </div>
                       </v-expansion-panel-content>
@@ -456,7 +444,7 @@
           genderArray: [], // 生徒の性別配列、テーブルを展開したもの、studentsName[]と順番が対応
           isAllDifferent: true, // 前回の座席と異なる配置にするかどうかの制御フラグ
           isFixGender: true, // 性別を固定するかどうかの制御フラグ
-          fixConditions: [], // 近づける条件配列
+          fixConditions: [['', '', '']], // 近づける条件配列
           fixConditionOption1: '', // 近づける生徒1
           fixConditionOption2: '', // 近づける生徒2
         },
@@ -475,6 +463,9 @@
           },
           createNewFarConditions(){
             this.farConditions.push(['', '', '']);
+          },
+          createNewFixConditions(){
+            this.fixConditions.push(['', '', '']);
           },
           /*getColorByIndex(col, row) { // 座席の種類に応じた色を返す
             if(this.genderTable[row][col] === '') {
@@ -857,15 +848,20 @@
           },
           placeFixedSeats() { // 固定する生徒を配置
             this.fixConditions.forEach(fixCondition => {
-              let fixConditionName = fixCondition[0];
-              let fixConditionRow = fixCondition[1]-1; // 入力された値とインデックスのずれを補正
-              let fixConditionCol = fixCondition[2]-1; // 入力された値とインデックスのずれを補正
-              this.nextSeatsTable[fixConditionRow].splice(fixConditionCol, 1, fixConditionName); // 固定する場所に配置
+              if(fixCondition[0] != ''){ // フォーム表示のため最後に['', '', '']が入ってしまっているので、そのときは処理しない
+                console.log(`fixCondition = ${fixCondition}`)
+                console.log(`fixCondition[0] = ${fixCondition[0]}`)
 
-              let fixIndex = [fixConditionCol, fixConditionRow]
-              this.delete(fixIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
-              this.delete(fixConditionName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
-              this.delete(fixConditionName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
+                let fixConditionName = fixCondition[0];
+                let fixConditionRow = fixCondition[1]-1; // 入力された値とインデックスのずれを補正
+                let fixConditionCol = fixCondition[2]-1; // 入力された値とインデックスのずれを補正
+                this.nextSeatsTable[fixConditionRow].splice(fixConditionCol, 1, fixConditionName); // 固定する場所に配置
+
+                let fixIndex = [fixConditionCol, fixConditionRow]
+                this.delete(fixIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
+                this.delete(fixConditionName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
+                this.delete(fixConditionName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
+              }
             })
           },
           minDistance(p1, p2) { // 2点の距離のminを返す。p1, p2は座標、たとえばp1=[1,2]

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
           <v-row>
             <!-- タイトル -->
             <v-col cols="12" style="background-color: wheat">
-              <h1 class="text-center">席替えメーカー（実装21日目）</h1>
+              <h1 class="text-center">席替えメーカー（実装22日目）</h1>
             </v-col>
           </v-row>
 

--- a/index.html
+++ b/index.html
@@ -99,15 +99,10 @@
                           <v-expansion-panel>
                             <v-expansion-panel-header>最前列</v-expansion-panel-header>
                             <v-expansion-panel-content>
-                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
-                              <span>
+                              <!-- 生徒の入力フォーム -->
+                              <span v-for="(frontCondition, frontIndex) in frontConditions">
                                 <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addFrontConditions"></v-select>
-                              </span>
-                              <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
-                              <span v-for="frontCondition in frontConditions">
-                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addFrontConditions"></v-select>
+                                v-model="frontConditions[frontIndex]" @change.once="createNewFrontConditions"></v-select>
                               </span>
                             </v-expansion-panel-content>
                           </v-expansion-panel>
@@ -424,7 +419,7 @@
           dupFarStudentsName: [], // 離す生徒の名前の複製
           nearFarStudentsName: [], // 近づける/離す生徒の名前
           dupNearFarStudentsName: [], // 近づける/離す生徒の名前の複製
-          frontConditions: [], // 最前列に固定する生徒
+          frontConditions: [''], // 最前列に固定する生徒
           frontSeatsIndex: [], // 最前列のインデックス
           dupFrontSeatsIndex: [], // 最前列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
           frontTwoRowsConditions: [], // 前2列に固定する生徒
@@ -450,11 +445,11 @@
         },
         methods: {
           testMethod() { // デバッグ用。最後に消す。
-            let testArray1 = ["aaa", "bbb", "ccc"]
-            let testArray2 = [[0,0], [1,1], [2,2]]
+            let testArray1 = ["aaa", "bbb", "ccc", '']
 
-            console.log(testArray1.originalIndexOf("ccc"))
-            console.log(testArray2.originalIndexOf([1,2]))
+            console.log(testArray1);
+            testArray1 = testArray1.filter(Boolean);
+            console.log(testArray1);
 
             console.log('---------')
           },
@@ -466,6 +461,9 @@
           },
           createNewFixConditions(){
             this.fixConditions.push(['', '', '']);
+          },
+          createNewFrontConditions(){
+            this.frontConditions.push('');
           },
           /*getColorByIndex(col, row) { // 座席の種類に応じた色を返す
             if(this.genderTable[row][col] === '') {
@@ -586,6 +584,7 @@
               this.makeFrontTwoRowsSeatsIndex(); // 前2列インデックスを作成
               this.makeBackSeatsIndex(); // 最後列インデックスを作成
               this.makeBackTwoRowsSeatsIndex(); // 後ろ2列インデックスを作成
+              this.frontConditions = this.frontConditions.filter(Boolean); // 空白を削除
               this.dupSeatsTableIndex = this.seatsTableIndex.slice(0); // 有効な座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupFrontSeatsIndex = this.frontSeatsIndex.slice(0); // 最前列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupFrontTwoRowsSeatsIndex = this.frontTwoRowsSeatsIndex.slice(0); // 前2列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
@@ -849,9 +848,6 @@
           placeFixedSeats() { // 固定する生徒を配置
             this.fixConditions.forEach(fixCondition => {
               if(fixCondition[0] != ''){ // フォーム表示のため最後に['', '', '']が入ってしまっているので、そのときは処理しない
-                console.log(`fixCondition = ${fixCondition}`)
-                console.log(`fixCondition[0] = ${fixCondition[0]}`)
-
                 let fixConditionName = fixCondition[0];
                 let fixConditionRow = fixCondition[1]-1; // 入力された値とインデックスのずれを補正
                 let fixConditionCol = fixCondition[2]-1; // 入力された値とインデックスのずれを補正
@@ -966,6 +962,15 @@
             },
             deep: true
           },
+          /*
+          frontConditions: {
+            handler: function(){
+              this.frontConditions = this.frontConditions.filter(function(frontConditions) { //空白を削除
+                return frontConditions !== '';
+              })
+            }
+          },
+          */
           nearConditions: {
             handler: function(){
               this.nearStudentsName.splice(-this.nearStudentsName.length); // 配列を初期化

--- a/index.html
+++ b/index.html
@@ -213,15 +213,15 @@
                       <v-expansion-panel-header>生徒同士を近づける</v-expansion-panel-header>
                       <v-expansion-panel-content>
                         <!-- 近づける生徒の入力フォーム -->
-                        <div v-for="(nearCondition, index) in nearConditions">
+                        <div v-for="(nearCondition, nearIndex) in nearConditions">
                           <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          v-model="nearConditions[index][0]"></v-select>
+                          v-model="nearConditions[nearIndex][0]"></v-select>
                           と
                           <v-select :items="studentsName" placeholder="Bさん" outlined style="width:200px; display: inline-block"
-                          v-model="nearConditions[index][1]"></v-select>
+                          v-model="nearConditions[nearIndex][1]"></v-select>
                           の間を
                           <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          v-model="nearConditions[index][2]" @change.once="createNewForms"></v-select>
+                          v-model="nearConditions[nearIndex][2]" @change.once="createNewNearConditions"></v-select>
                           以下にする
                         </div>
                       </v-expansion-panel-content>
@@ -235,28 +235,16 @@
                     <v-expansion-panel>
                       <v-expansion-panel-header>生徒同士を離す</v-expansion-panel-header>
                       <v-expansion-panel-content>
-                        <!-- 離す生徒の入力フォーム（初期表示のための１つ目） -->
-                        <div>
+                        <!-- 離す生徒の入力フォーム -->
+                        <div v-for="(farCondition, farIndex) in farConditions">
                           <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setFarConditionOption1"></v-select>
+                          v-model="farConditions[farIndex][0]"></v-select>
                           と
                           <v-select :items="studentsName" placeholder="Bさん" outlined style="width:200px; display: inline-block"
-                          @change="setFarConditionOption2"></v-select>
+                          v-model="farConditions[farIndex][1]"></v-select>
                           の間を
                           <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addFarConditions"></v-select>
-                          以上にする
-                        </div>
-                        <!-- 離す生徒の入力フォーム（追加表示のための２つ目以降） -->
-                        <div v-for="farCondition in farConditions">
-                          <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setFarConditionOption1"></v-select>
-                          と
-                          <v-select :items="studentsName" placeholder="Bさん" outlined style="width:200px; display: inline-block"
-                          @change="setFarConditionOption2"></v-select>
-                          の間を
-                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addFarConditions"></v-select>
+                          v-model="farConditions[farIndex][2]" @change.once="createNewFarConditions"></v-select>
                           以上にする
                         </div>
                       </v-expansion-panel-content>
@@ -441,7 +429,7 @@
           nearConditionOption2: '', // 近づける生徒2
           nearStudentsName: [], // 近づける生徒の名前
           dupNearStudentsName: [], // 近づける生徒の名前の複製
-          farConditions: [], // 離す条件
+          farConditions: [['', '', '']], // 離す条件用配列
           farConditionOption1: '', // 離す生徒1
           farConditionOption2: '', // 離す生徒2
           farStudentsName: [], // 離す生徒の名前
@@ -482,8 +470,11 @@
 
             console.log('---------')
           },
-          createNewForms(){
+          createNewNearConditions(){
             this.nearConditions.push(['', '', '']);
+          },
+          createNewFarConditions(){
+            this.farConditions.push(['', '', '']);
           },
           /*getColorByIndex(col, row) { // 座席の種類に応じた色を返す
             if(this.genderTable[row][col] === '') {
@@ -998,6 +989,9 @@
                 this.farStudentsName.push(farCondition[0], farCondition[1]);
               })
               this.farStudentsName = Array.from(new Set(this.farStudentsName)) // 重複している名前を削除
+              this.farStudentsName = this.farStudentsName.filter(function(farStudentsName) { //空白を削除
+                return farStudentsName !== '';
+              })
             }
           },
           genderTable: {

--- a/index.html
+++ b/index.html
@@ -212,28 +212,16 @@
                     <v-expansion-panel>
                       <v-expansion-panel-header>生徒同士を近づける</v-expansion-panel-header>
                       <v-expansion-panel-content>
-                        <!-- 近づける生徒の入力フォーム（初期表示のための１つ目） -->
-                        <div>
+                        <!-- 近づける生徒の入力フォーム -->
+                        <div v-for="(nearCondition, index) in nearConditions">
                           <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setNearConditionOption1"></v-select>
+                          v-model="nearConditions[index][0]"></v-select>
                           と
                           <v-select :items="studentsName" placeholder="Bさん" outlined style="width:200px; display: inline-block"
-                          @change="setNearConditionOption2"></v-select>
+                          v-model="nearConditions[index][1]"></v-select>
                           の間を
                           <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addNearConditions"></v-select>
-                          以下にする
-                        </div>
-                        <!-- 近づける生徒の入力フォーム（追加表示のための２つ目以降） -->
-                        <div v-for="nearCondition in nearConditions">
-                          <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setNearConditionOption1"></v-select>
-                          と
-                          <v-select :items="studentsName" placeholder="Bさん" outlined style="width:200px; display: inline-block"
-                          @change="setNearConditionOption2"></v-select>
-                          の間を
-                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addNearConditions"></v-select>
+                          v-model="nearConditions[index][2]" @change.once="createNewForms"></v-select>
                           以下にする
                         </div>
                       </v-expansion-panel-content>
@@ -448,7 +436,7 @@
           distanceOptions: [1,2,3,4,5,6,7,8], // 近づける・離す距離の選択肢
           studentsName: [], // 生徒の名前配列、席替えボタンが2回以上押されたときに元の生徒名を記憶しておくため
           dupStudentsName: [], // 生徒の名前配列の複製、席替えの際に破壊的にデータを取り出していく
-          nearConditions: [], // 近づける条件配列
+          nearConditions: [['', '', '']], // 近づける条件配列
           nearConditionOption1: '', // 近づける生徒1
           nearConditionOption2: '', // 近づける生徒2
           nearStudentsName: [], // 近づける生徒の名前
@@ -493,6 +481,9 @@
             console.log(testArray2.originalIndexOf([1,2]))
 
             console.log('---------')
+          },
+          createNewForms(){
+            this.nearConditions.push(['', '', '']);
           },
           /*getColorByIndex(col, row) { // 座席の種類に応じた色を返す
             if(this.genderTable[row][col] === '') {
@@ -995,6 +986,9 @@
                 this.nearStudentsName.push(nearCondition[0], nearCondition[1]);
               })
               this.nearStudentsName = Array.from(new Set(this.nearStudentsName)) // 重複している名前を削除
+              this.nearStudentsName = this.nearStudentsName.filter(function(nearStudentsName) { //空白を削除
+                return nearStudentsName !== '';
+              })
             }
           },
           farConditions: {

--- a/index.html
+++ b/index.html
@@ -111,15 +111,10 @@
                           <v-expansion-panel>
                             <v-expansion-panel-header>前2列</v-expansion-panel-header>
                             <v-expansion-panel-content>
-                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
-                              <span>
+                              <!-- 生徒の入力フォーム -->
+                              <span v-for="(frontTwoRowsCondition, frontTwoRowsIndex) in frontTwoRowsConditions">
                                 <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addFrontTwoRowsConditions"></v-select>
-                              </span>
-                              <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
-                              <span v-for="frontTwoRowsCondition in frontTwoRowsConditions">
-                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addFrontTwoRowsConditions"></v-select>
+                                v-model="frontTwoRowsConditions[frontTwoRowsIndex]" @change.once="createNewFrontTwoRowsConditions"></v-select>
                               </span>
                             </v-expansion-panel-content>
                           </v-expansion-panel>
@@ -128,15 +123,10 @@
                           <v-expansion-panel>
                             <v-expansion-panel-header>後ろ2列</v-expansion-panel-header>
                             <v-expansion-panel-content>
-                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
-                              <span>
+                              <!-- 生徒の入力フォーム -->
+                              <span v-for="(backTwoRowsCondition, backTwoRowsIndex) in backTwoRowsConditions">
                                 <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addBackTwoRowsConditions"></v-select>
-                              </span>
-                              <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
-                              <span v-for="backTwoRowsCondition in backTwoRowsConditions">
-                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addBackTwoRowsConditions"></v-select>
+                                v-model="backTwoRowsConditions[backTwoRowsIndex]" @change.once="createNewBackTwoRowsConditions"></v-select>
                               </span>
                             </v-expansion-panel-content>
                           </v-expansion-panel>
@@ -145,15 +135,10 @@
                           <v-expansion-panel>
                             <v-expansion-panel-header>最後列</v-expansion-panel-header>
                             <v-expansion-panel-content>
-                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
-                              <span>
-                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addBackConditions"></v-select>
-                              </span>
                               <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
-                              <span v-for="backCondition in backConditions">
+                              <span v-for="(backCondition, backIndex) in backConditions">
                                 <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addBackConditions"></v-select>
+                                v-model="backConditions[backIndex]" @change.once="createNewBackConditions"></v-select>
                               </span>
                             </v-expansion-panel-content>
                           </v-expansion-panel>
@@ -422,13 +407,13 @@
           frontConditions: [''], // 最前列に固定する生徒
           frontSeatsIndex: [], // 最前列のインデックス
           dupFrontSeatsIndex: [], // 最前列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
-          frontTwoRowsConditions: [], // 前2列に固定する生徒
+          frontTwoRowsConditions: [''], // 前2列に固定する生徒
           frontTwoRowsSeatsIndex: [], // 前2列のインデックス
           dupFrontTwoRowsSeatsIndex: [], // 前2列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
-          backConditions: [], // 最後列に固定する生徒
+          backConditions: [''], // 最後列に固定する生徒
           backSeatsIndex: [], // 最後列のインデックス
           dupBackSeatsIndex: [], // 最前列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
-          backTwoRowsConditions: [], // 後ろ2列に固定する生徒
+          backTwoRowsConditions: [''], // 後ろ2列に固定する生徒
           backTwoRowsSeatsIndex: [], // 後ろ2列のインデックス
           dupBackTwoRowsSeatsIndex: [], // 後ろ2列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
           nextSeatsTable: [], // 席替え後の座席テーブル
@@ -464,6 +449,15 @@
           },
           createNewFrontConditions(){
             this.frontConditions.push('');
+          },
+          createNewFrontTwoRowsConditions(){
+            this.frontTwoRowsConditions.push('');
+          },
+          createNewBackTwoRowsConditions(){
+            this.backTwoRowsConditions.push('');
+          },
+          createNewBackConditions(){
+            this.backConditions.push('');
           },
           /*getColorByIndex(col, row) { // 座席の種類に応じた色を返す
             if(this.genderTable[row][col] === '') {
@@ -585,6 +579,9 @@
               this.makeBackSeatsIndex(); // 最後列インデックスを作成
               this.makeBackTwoRowsSeatsIndex(); // 後ろ2列インデックスを作成
               this.frontConditions = this.frontConditions.filter(Boolean); // 空白を削除
+              this.frontTwoRowsConditions = this.frontTwoRowsConditions.filter(Boolean); // 空白を削除
+              this.backConditions = this.backConditions.filter(Boolean); // 空白を削除
+              this.backTwoRowsConditions = this.backTwoRowsConditions.filter(Boolean); // 空白を削除
               this.dupSeatsTableIndex = this.seatsTableIndex.slice(0); // 有効な座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupFrontSeatsIndex = this.frontSeatsIndex.slice(0); // 最前列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupFrontTwoRowsSeatsIndex = this.frontTwoRowsSeatsIndex.slice(0); // 前2列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
@@ -605,6 +602,11 @@
               //this.changeFarSeats(); // 離す生徒を席替え
               this.changeNearFarSeats(); // 近づける/離す生徒を席替え
               this.shuffleSeats(); // 条件のない生徒を席替え
+
+              this.createNewFrontConditions(); // 次回の準備、最前列のフォームを1つ作成
+              this.createNewFrontTwoRowsConditions(); // 次回の準備、前2列のフォームを1つ作成
+              this.createNewBackTwoRowsConditions(); // 次回の準備、後2列のフォームを1つ作成
+              this.createNewBackConditions(); // 次回の準備、最後列のフォームを1つ作成
               console.log(`----${loopNum}回目のループ終了----`);
             } while(this.restartFlag && loopNum <= 100)
             console.log(`====終了====`);
@@ -699,6 +701,7 @@
               this.delete(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
               this.delete(frontStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
               this.delete(frontStudentName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
+              this.delete(topIndex, this.dupFrontTwoRowsSeatsIndex); // ここで配置した座標はchangeFrontTwoRowsSeats()で使えないため、座席座標を削除する
             })
           },
           changeFrontTwoRowsSeats() { // 前2列に固定する生徒を席替え
@@ -741,6 +744,7 @@
               this.delete(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
               this.delete(backStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
               this.delete(backStudentName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
+              this.delete(topIndex, this.dupBackTwoRowsSeatsIndex); // ここで配置した座標はchangeBackTwoRowsSeats()で使えないため、座席座標を削除する
             })
           },
           changeBackTwoRowsSeats() { // 後ろ2列に固定する生徒を席替え


### PR DESCRIPTION
- v-modelを用いて入力フォームを双方向バインディングし、データの整合性を取れるように修正
- 配置系メソッドを正常に動作させるために、席替え前に生徒名配列から空白を削除するように修正
- 配置系メソッド後に、ビュー側にフォームを1つ表示させておくために、createNewForm()を実行