### PR TITLE
[Fix] 距離の選択肢に実現不可能な値が含まれていたので、watchでX/Yを監視して選ばれた値によって動的に選択肢を変更するように修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
           <v-row>
             <!-- タイトル -->
             <v-col cols="12" style="background-color: wheat">
-              <h1 class="text-center">席替えメーカー（実装20日目）</h1>
+              <h1 class="text-center">席替えメーカー（実装21日目）</h1>
             </v-col>
           </v-row>
 
@@ -619,8 +619,8 @@
               this.dupBackSeatsIndex = this.backSeatsIndex.slice(0); // 最後列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupBackTwoRowsSeatsIndex = this.backTwoRowsSeatsIndex.slice(0); // 後ろ2列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupStudentsName = this.studentsName.slice(0); // 生徒名を複製、席替えの際にこの配列から破壊的にデータを取り出していく
-              this.dupNearStudentsName = this.nearStudentsName.slice(0); // 近づける生徒名を複製、席替えの際にこの配列から破壊的にデータを取り出していく
-              this.dupFarStudentsName = this.farStudentsName.slice(0); // 離す生徒名を複製、席替えの際にこの配列から破壊的にデータを取り出していく
+              //this.dupNearStudentsName = this.nearStudentsName.slice(0); // 近づける生徒名を複製、席替えの際にこの配列から破壊的にデータを取り出していく
+              //this.dupFarStudentsName = this.farStudentsName.slice(0); // 離す生徒名を複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupNearFarStudentsName = this.nearStudentsName.concat(this.farStudentsName); // 近づける生徒名と離す生徒名を結合、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupNearFarStudentsName = Array.from(new Set(this.dupNearFarStudentsName)) // 重複している名前を削除
 
@@ -712,7 +712,7 @@
             this.shuffle(this.dupFrontSeatsIndex);
             this.frontConditions.forEach(frontStudentName => {
               let topIndex = this.dupFrontSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
-              /* ----近づける/離す/性別チェック---- */
+              // ----近づける/離す/性別チェック----
               while( !this.checkNear(frontStudentName, topIndex) || !this.checkFar(frontStudentName, topIndex) || ( this.isFixGender && !this.checkGender(frontStudentName, topIndex)) ){ // どちらかの条件を満たさない間、繰り返す
                 if(this.calcNum > this.seatsNum){
                   this.restartFlag = true;
@@ -722,37 +722,18 @@
                 topIndex = this.dupFrontSeatsIndex.shift(); // 配列先頭のインデックスを再度取り出す
                 this.calcNum += 1;
               }
-              /* ----ここまで---- */
+              // ----ここまで----
               this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, frontStudentName); // 取り出したインデックスの位置に生徒名を保存
-
-              let deleteIndex = this.dupSeatsTableIndex.indexOf(topIndex); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
-              this.dupSeatsTableIndex.splice(deleteIndex, 1); // dupSeatsTableIndexから削除する
-
-              let deleteStudentNameIndex = this.dupStudentsName.indexOf(frontStudentName); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
-              this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
-
-              let deleteNearStudentNameIndex = this.dupNearStudentsName.indexOf(frontStudentName); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
-              if(deleteNearStudentNameIndex != -1){ // dupNearStudentsNameにあれば削除する
-                this.dupNearStudentsName.splice(deleteNearStudentNameIndex, 1); // dupNearStudentsNameから削除する
-              }
-
-              let deleteFarStudentNameIndex = this.dupFarStudentsName.indexOf(frontStudentName); // ここで配置した生徒は、changeFarSeats()で配置する必要がないため
-              if(deleteFarStudentNameIndex != -1){ // dupFarStudentsNameにあれば削除する
-                this.dupFarStudentsName.splice(deleteFarStudentNameIndex, 1); // dupFarStudentsNameから削除する
-              }
-
-              let deleteNearFarStudentNameIndex = this.dupNearFarStudentsName.indexOf(frontStudentName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため
-              if(deleteNearFarStudentNameIndex != -1){ // dupNearFarStudentsNameにあれば削除する
-                this.dupNearFarStudentsName.splice(deleteNearFarStudentNameIndex, 1); // dupNearFarStudentsNameから削除する
-              }
-              // console.log(`${frontStudentName}を配置した`)
+              this.delete(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
+              this.delete(frontStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
+              this.delete(frontStudentName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
             })
           },
           changeFrontTwoRowsSeats() { // 前2列に固定する生徒を席替え
             this.shuffle(this.dupFrontTwoRowsSeatsIndex);
             this.frontTwoRowsConditions.forEach(frontTwoRowsStudentName => {
               let topIndex = this.dupFrontTwoRowsSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
-              /* ----近づける/離す/性別チェック---- */
+              // ----近づける/離す/性別チェック----
               while( !this.checkNear(frontTwoRowsStudentName, topIndex) || !this.checkFar(frontTwoRowsStudentName, topIndex) || ( this.isFixGender && !this.checkGender(frontTwoRowsStudentName, topIndex)) ){ // どちらかの条件を満たさない間、繰り返す
                 if(this.calcNum > this.seatsNum){
                   this.restartFlag = true;
@@ -762,37 +743,18 @@
                 topIndex = this.dupFrontTwoRowsSeatsIndex.shift(); // 配列先頭のインデックスを再度取り出す
                 this.calcNum += 1;
               }
-              /* ----ここまで---- */
+              // ----ここまで----
               this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, frontTwoRowsStudentName); // 取り出したインデックスの位置に生徒名を保存
-
-              let deleteIndex = this.dupSeatsTableIndex.indexOf(topIndex); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
-              this.dupSeatsTableIndex.splice(deleteIndex, 1); // dupSeatsTableIndexから削除する
-
-              let deleteStudentNameIndex = this.dupStudentsName.indexOf(frontTwoRowsStudentName); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
-              this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
-
-              let deleteNearStudentNameIndex = this.dupNearStudentsName.indexOf(frontTwoRowsStudentName); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
-              if(deleteNearStudentNameIndex != -1){ // dupNearStudentsNameにあれば削除する
-                this.dupNearStudentsName.splice(deleteNearStudentNameIndex, 1); // dupNearStudentsNameから削除する
-              }
-
-              let deleteFarStudentNameIndex = this.dupFarStudentsName.indexOf(frontTwoRowsStudentName); // ここで配置した生徒は、changeFarSeats()で配置する必要がないため
-              if(deleteFarStudentNameIndex != -1){ // dupFarStudentsNameにあれば削除する
-                this.dupFarStudentsName.splice(deleteFarStudentNameIndex, 1); // dupFarStudentsNameから削除する
-              }
-
-              let deleteNearFarStudentNameIndex = this.dupNearFarStudentsName.indexOf(frontTwoRowsStudentName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため
-              if(deleteNearFarStudentNameIndex != -1){ // dupNearFarStudentsNameにあれば削除する
-                this.dupNearFarStudentsName.splice(deleteNearFarStudentNameIndex, 1); // dupNearFarStudentsNameから削除する
-              }
-              // console.log(`${frontStudentName}を配置した`)
+              this.delete(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
+              this.delete(frontTwoRowsStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
+              this.delete(frontTwoRowsStudentName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
             })
           },
           changeBackSeats() { // 最後列に固定する生徒を席替え
             this.shuffle(this.dupBackSeatsIndex);
             this.backConditions.forEach(backStudentName => {
               let topIndex = this.dupBackSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
-              /* ----近づける/離す/性別チェック---- */
+              // ----近づける/離す/性別チェック----
               while( !this.checkNear(backStudentName, topIndex) || !this.checkFar(backStudentName, topIndex) || ( this.isFixGender && !this.checkGender(backStudentName, topIndex)) ){ // どちらかの条件を満たさない間、繰り返す
                 if(this.calcNum > this.seatsNum){
                   this.restartFlag = true;
@@ -802,37 +764,21 @@
                 topIndex = this.dupBackSeatsIndex.shift(); // 配列先頭のインデックスを再度取り出す
                 this.calcNum += 1;
               }
-              /* ----ここまで---- */
+              // ----ここまで----
               this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, backStudentName); // 取り出したインデックスの位置に生徒名を保存
-
-              let deleteIndex = this.dupSeatsTableIndex.indexOf(topIndex); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
-              this.dupSeatsTableIndex.splice(deleteIndex, 1); // dupSeatsTableIndexから削除する
-
-              let deleteStudentNameIndex = this.dupStudentsName.indexOf(backStudentName); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
-              this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
-
-              let deleteNearStudentNameIndex = this.dupNearStudentsName.indexOf(backStudentName); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
-              if(deleteNearStudentNameIndex != -1){ // dupNearStudentsNameにあれば削除する
-                this.dupNearStudentsName.splice(deleteNearStudentNameIndex, 1); // dupNearStudentsNameから削除する
-              }
-
-              let deleteFarStudentNameIndex = this.dupFarStudentsName.indexOf(backStudentName); // ここで配置した生徒は、changeFarSeats()で配置する必要がないため
-              if(deleteFarStudentNameIndex != -1){ // dupFarStudentsNameにあれば削除する
-                this.dupFarStudentsName.splice(deleteFarStudentNameIndex, 1); // dupFarStudentsNameから削除する
-              }
-
-              let deleteNearFarStudentNameIndex = this.dupNearFarStudentsName.indexOf(backStudentName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため
-              if(deleteNearFarStudentNameIndex != -1){ // dupNearFarStudentsNameにあれば削除する
-                this.dupNearFarStudentsName.splice(deleteNearFarStudentNameIndex, 1); // dupNearFarStudentsNameから削除する
-              }
-              // console.log(`${backStudentName}を配置した`)
+              this.delete(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
+              this.delete(backStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
+              this.delete(backStudentName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
             })
           },
           changeBackTwoRowsSeats() { // 後ろ2列に固定する生徒を席替え
             this.shuffle(this.dupBackTwoRowsSeatsIndex);
             this.backTwoRowsConditions.forEach(backTwoRowsStudentName => {
+              if(!this.dupBackTwoRowsSeatsIndex.length){
+                // todo エラーを表示してbreak
+              }
               let topIndex = this.dupBackTwoRowsSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
-              /* ----近づける/離す/性別チェック---- */
+              // ----近づける/離す/性別チェック----
               while( !this.checkNear(backTwoRowsStudentName, topIndex) || !this.checkFar(backTwoRowsStudentName, topIndex) || ( this.isFixGender && !this.checkGender(backTwoRowsStudentName, topIndex)) ){ // どちらかの条件を満たさない間、繰り返す
                 if(this.calcNum > this.seatsNum){
                   this.restartFlag = true;
@@ -842,30 +788,11 @@
                 topIndex = this.dupBackTwoRowsSeatsIndex.shift(); // 配列先頭のインデックスを再度取り出す
                 this.calcNum += 1;
               }
-              /* ----ここまで---- */
+              // ----ここまで----
               this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, backTwoRowsStudentName); // 取り出したインデックスの位置に生徒名を保存
-
-              let deleteIndex = this.dupSeatsTableIndex.indexOf(topIndex); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
-              this.dupSeatsTableIndex.splice(deleteIndex, 1); // dupSeatsTableIndexから削除する
-
-              let deleteStudentNameIndex = this.dupStudentsName.indexOf(backTwoRowsStudentName); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
-              this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
-
-              let deleteNearStudentNameIndex = this.dupNearStudentsName.indexOf(backTwoRowsStudentName); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
-              if(deleteNearStudentNameIndex != -1){ // dupNearStudentsNameにあれば削除する
-                this.dupNearStudentsName.splice(deleteNearStudentNameIndex, 1); // dupNearStudentsNameから削除する
-              }
-
-              let deleteFarStudentNameIndex = this.dupFarStudentsName.indexOf(backTwoRowsStudentName); // ここで配置した生徒は、changeFarSeats()で配置する必要がないため
-              if(deleteFarStudentNameIndex != -1){ // dupFarStudentsNameにあれば削除する
-                this.dupFarStudentsName.splice(deleteFarStudentNameIndex, 1); // dupFarStudentsNameから削除する
-              }
-
-              let deleteNearFarStudentNameIndex = this.dupNearFarStudentsName.indexOf(backTwoRowsStudentName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため
-              if(deleteNearFarStudentNameIndex != -1){ // dupNearFarStudentsNameにあれば削除する
-                this.dupNearFarStudentsName.splice(deleteNearFarStudentNameIndex, 1); // dupNearFarStudentsNameから削除する
-              }
-              // console.log(`${backStudentName}を配置した`)
+              this.delete(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除
+              this.delete(backTwoRowsStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除
+              this.delete(backTwoRowsStudentName, this.dupNearFarStudentsName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため、生徒名を削除する
             })
           },
           /*
@@ -931,26 +858,19 @@
             this.shuffle(this.dupSeatsTableIndex);
             this.dupNearFarStudentsName.forEach(dupNearFarStudentName => {
               let topIndex = this.dupSeatsTableIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
-              //console.log(`${dupNearStudentName} を ${topIndex} に入れるのは ${this.checkNear(dupNearStudentName, topIndex)} (${this.calcNum}回目の計算)`);
-              /* ----近づける/離す処理---- */
+              // ----近づける/離す処理----
               while( !this.checkNear(dupNearFarStudentName, topIndex) || !this.checkFar(dupNearFarStudentName, topIndex) || (this.isFixGender && !this.checkGender(dupNearFarStudentName, topIndex)) ){ // どちらかの条件を満たさない間、繰り返す
                 if(this.calcNum > this.seatsNum){
-                  //window.alert('条件を満たす席替えを実現できませんでした。\n何回か試してもエラーが出るようでしたら、条件を変更してください。');
                   this.restartFlag = true;
-                  //window.alert('restartFlagをtrueにしました。');
                   break;
                 }
                 this.dupSeatsTableIndex.push(topIndex); // 取り出したインデックスを配列の最後にプッシュして
                 topIndex = this.dupSeatsTableIndex.shift(); // 配列先頭のインデックスを再度取り出す
-                //console.log(`${dupNearFarStudentName} を ${topIndex} に入れるとき、checkNearは ${this.checkNear(dupNearFarStudentName, topIndex)}、checkFarは ${this.checkFar(dupNearFarStudentName, topIndex)} (while内${this.calcNum}回目の計算)`);
                 this.calcNum += 1;
               }
-              /* ----ここまで---- */
+              // ----ここまで----
               this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, dupNearFarStudentName); // 取り出したインデックスの位置に生徒名を保存
-
-              let deleteStudentNameIndex = this.dupStudentsName.indexOf(dupNearFarStudentName); // changeNearSeats()で配置した生徒は、shuffleSeats()で配置する必要がないため
-              this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
-              // console.log(`${dupNearFarStudentName}を配置した`)
+              this.delete(dupNearFarStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
             })
           },
           placeFixedSeats() { // 固定する生徒を配置
@@ -961,45 +881,17 @@
               this.nextSeatsTable[fixConditionRow].splice(fixConditionCol, 1, fixConditionName); // 固定する場所に配置
 
               let fixIndex = [fixConditionCol, fixConditionRow]
-
-              let deleteIndex = this.dupSeatsTableIndex.originalIndexOf(fixIndex); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
-              if(deleteIndex != -1){
-                this.dupSeatsTableIndex.splice(deleteIndex, 1); // dupSeatsTableIndexから削除する
-              }
-
-              let deleteStudentNameIndex = this.dupStudentsName.indexOf(fixConditionName); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
-              this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
-
-              // todo frontIndexからも消す
-              let deleteFrontSeatsIndex = this.dupFrontSeatsIndex.originalIndexOf(fixIndex); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
-              if(deleteFrontSeatsIndex != -1){ // dupNearStudentsNameにあれば削除する
-                this.dupFrontSeatsIndex.splice(deleteFrontSeatsIndex, 1); // dupNearStudentsNameから削除する
-              }
-
-
-              let deleteNearStudentNameIndex = this.dupNearStudentsName.indexOf(fixConditionName); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
-              if(deleteNearStudentNameIndex != -1){ // dupNearStudentsNameにあれば削除する
-                this.dupNearStudentsName.splice(deleteNearStudentNameIndex, 1); // dupNearStudentsNameから削除する
-              }
-
-              let deleteFarStudentNameIndex = this.dupFarStudentsName.indexOf(fixConditionName); // ここで配置した生徒は、changeFarSeats()で配置する必要がないため
-              if(deleteFarStudentNameIndex != -1){ // dupFarStudentsNameにあれば削除する
-                this.dupFarStudentsName.splice(deleteFarStudentNameIndex, 1); // dupFarStudentsNameから削除する
-              }
-
-              let deleteNearFarStudentNameIndex = this.dupNearFarStudentsName.indexOf(fixConditionName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため
-              if(deleteNearFarStudentNameIndex != -1){ // dupNearFarStudentsNameにあれば削除する
-                this.dupNearFarStudentsName.splice(deleteNearFarStudentNameIndex, 1); // dupNearFarStudentsNameから削除する
-              }
-
+              this.delete(fixIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
+              this.delete(fixConditionName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
+              this.delete(fixConditionName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
             })
           },
-          min_distance(p1, p2) { // 2点の距離のminを返す。p1, p2は座標、たとえばp1=[1,2]
+          minDistance(p1, p2) { // 2点の距離のminを返す。p1, p2は座標、たとえばp1=[1,2]
             let x_abs = Math.abs( p1[0] - p2[0] );
             let y_abs = Math.abs( p1[1] - p2[1] );
             return Math.min(x_abs, y_abs);
           },
-          max_distance(p1, p2) { // 2点の距離のmaxを返す。p1, p2は座標、たとえばp1=[1,2]
+          maxDistance(p1, p2) { // 2点の距離のmaxを返す。p1, p2は座標、たとえばp1=[1,2]
             let x_abs = Math.abs( p1[0] - p2[0] );
             let y_abs = Math.abs( p1[1] - p2[1] );
             return Math.max(x_abs, y_abs);
@@ -1008,19 +900,17 @@
             let return_value = true
             this.nearConditions.forEach(nearConditionArray => {
               if( nearConditionArray.includes(studentName) ){ // もし引数の生徒が、近づける条件にいれば
-                /* ----近づけたい生徒の名前を取得---- */
+                // ----近づけたい生徒の名前を取得----
                 let nearStudentName
                 if( nearConditionArray.indexOf(studentName) == 0 ){
                   nearStudentName = nearConditionArray[1]; // 引数の生徒と近づけたい生徒
                 }else if( nearConditionArray.indexOf(studentName) == 1 ){
                   nearStudentName = nearConditionArray[0]; // 引数の生徒と近づけたい生徒
                 }
-                /* ----ここまで---- */
+                // ----ここまで----
                 let distance = nearConditionArray[2]; // 距離
                 let nearStudentPosition = this.getPositionFromNextSeatsTable(nearStudentName); // すでに配置されていればその座標、まだ配置されてなければfalse
-                // console.log(`${nearStudentName} の場所は ${nearStudentPosition}`);
-                // console.log(`距離は${this.max_distance(p, nearStudentPosition)}`);
-                if( this.max_distance(p, nearStudentPosition) > distance ){ // 距離のmaxが条件distanceより上なら返り値をfalseに更新
+                if( this.maxDistance(p, nearStudentPosition) > distance ){ // 距離のmaxが条件distanceより上なら返り値をfalseに更新
                   return_value = false;
                 }
               }
@@ -1031,19 +921,17 @@
             let return_value = true
             this.farConditions.forEach(farConditionArray => {
               if( farConditionArray.includes(studentName) ){ // もし引数の生徒が、離す条件にいれば
-                /* ----離す生徒の名前を取得---- */
+                // ----離す生徒の名前を取得----
                 let farStudentName
                 if( farConditionArray.indexOf(studentName) == 0 ){
                   farStudentName = farConditionArray[1]; // 引数の生徒と離す生徒
                 }else if( farConditionArray.indexOf(studentName) == 1 ){
                   farStudentName = farConditionArray[0]; // 引数の生徒と離す生徒
                 }
-                /* ----ここまで---- */
+                // ----ここまで----
                 let distance = farConditionArray[2]; // 距離
                 let farStudentPosition = this.getPositionFromNextSeatsTable(farStudentName); // すでに配置されていればその座標、まだ配置されてなければfalse
-                // console.log(`${nearStudentName} の場所は ${nearStudentPosition}`);
-                // console.log(`距離は${this.max_distance(p, nearStudentPosition)}`);
-                if( this.max_distance(p, farStudentPosition) < distance ){ // 距離のminが条件distanceより下なら返り値をfalseに更新
+                if( this.maxDistance(p, farStudentPosition) < distance ){ // 距離のminが条件distanceより下なら返り値をfalseに更新
                   return_value = false;
                 }
               }
@@ -1077,7 +965,13 @@
             for(let i = 0; i < this.seatsSizeY; i++) {
               this.genderTable.push( Array(this.seatsSizeX).fill('') ) // すべての席に性別が未入力な状態でテーブルを作成
             }
-          }
+          },
+          delete(target, array){
+            let deleteIndex = array.originalIndexOf(target); // 削除したいtargetがある配列arrayのインデックスを取得
+            if(deleteIndex != -1){ // targetが配列arrayになければ返り値が-1となるので、そのときは削除しない
+              array.splice(deleteIndex, 1); // arrayからtargetを削除する
+            }
+          },
         },
         mounted() {
           this.makeSeatsTable() // 最初にseatsTableを作成

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
           <v-row>
             <!-- タイトル -->
             <v-col cols="12" style="background-color: wheat">
-              <h1 class="text-center">席替えメーカー（実装21日目）</h1>
+              <h1 class="text-center">席替えメーカー（実装22日目）</h1>
             </v-col>
           </v-row>
 
@@ -99,15 +99,10 @@
                           <v-expansion-panel>
                             <v-expansion-panel-header>最前列</v-expansion-panel-header>
                             <v-expansion-panel-content>
-                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
-                              <span>
+                              <!-- 生徒の入力フォーム -->
+                              <span v-for="(frontCondition, frontIndex) in frontConditions">
                                 <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addFrontConditions"></v-select>
-                              </span>
-                              <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
-                              <span v-for="frontCondition in frontConditions">
-                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addFrontConditions"></v-select>
+                                v-model="frontConditions[frontIndex]" @change.once="createNewFrontConditions"></v-select>
                               </span>
                             </v-expansion-panel-content>
                           </v-expansion-panel>
@@ -116,15 +111,10 @@
                           <v-expansion-panel>
                             <v-expansion-panel-header>前2列</v-expansion-panel-header>
                             <v-expansion-panel-content>
-                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
-                              <span>
+                              <!-- 生徒の入力フォーム -->
+                              <span v-for="(frontTwoRowsCondition, frontTwoRowsIndex) in frontTwoRowsConditions">
                                 <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addFrontTwoRowsConditions"></v-select>
-                              </span>
-                              <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
-                              <span v-for="frontTwoRowsCondition in frontTwoRowsConditions">
-                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addFrontTwoRowsConditions"></v-select>
+                                v-model="frontTwoRowsConditions[frontTwoRowsIndex]" @change.once="createNewFrontTwoRowsConditions"></v-select>
                               </span>
                             </v-expansion-panel-content>
                           </v-expansion-panel>
@@ -133,15 +123,10 @@
                           <v-expansion-panel>
                             <v-expansion-panel-header>後ろ2列</v-expansion-panel-header>
                             <v-expansion-panel-content>
-                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
-                              <span>
+                              <!-- 生徒の入力フォーム -->
+                              <span v-for="(backTwoRowsCondition, backTwoRowsIndex) in backTwoRowsConditions">
                                 <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addBackTwoRowsConditions"></v-select>
-                              </span>
-                              <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
-                              <span v-for="backTwoRowsCondition in backTwoRowsConditions">
-                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addBackTwoRowsConditions"></v-select>
+                                v-model="backTwoRowsConditions[backTwoRowsIndex]" @change.once="createNewBackTwoRowsConditions"></v-select>
                               </span>
                             </v-expansion-panel-content>
                           </v-expansion-panel>
@@ -150,15 +135,10 @@
                           <v-expansion-panel>
                             <v-expansion-panel-header>最後列</v-expansion-panel-header>
                             <v-expansion-panel-content>
-                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
-                              <span>
-                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addBackConditions"></v-select>
-                              </span>
                               <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
-                              <span v-for="backCondition in backConditions">
+                              <span v-for="(backCondition, backIndex) in backConditions">
                                 <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                                @change="addBackConditions"></v-select>
+                                v-model="backConditions[backIndex]" @change.once="createNewBackConditions"></v-select>
                               </span>
                             </v-expansion-panel-content>
                           </v-expansion-panel>
@@ -176,28 +156,16 @@
                     <v-expansion-panel>
                       <v-expansion-panel-header>特定の席に固定する</v-expansion-panel-header>
                       <v-expansion-panel-content>
-                        <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
-                        <div>
+                        <!-- 生徒の入力フォーム -->
+                        <div v-for="(fixCondition, fixIndex) in fixConditions">
                           <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setFixConditionOption1"></v-select>
+                          v-model="fixConditions[fixIndex][0]"></v-select>
                           を、前から
                           <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="setFixConditionOption2"></v-select>
+                          v-model="fixConditions[fixIndex][1]"></v-select>
                           列目、左から
                           <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addFixConditions"></v-select>
-                          列目に固定する
-                        </div>
-                        <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
-                        <div v-for="fixCondition in fixConditions">
-                          <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setFixConditionOption1"></v-select>
-                          を、前から
-                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="setFixConditionOption2"></v-select>
-                          列目、左から
-                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addFixConditions"></v-select>
+                          v-model="fixConditions[fixIndex][2]" @change.once="createNewFixConditions"></v-select>
                           列目に固定する
                         </div>
                       </v-expansion-panel-content>
@@ -212,28 +180,16 @@
                     <v-expansion-panel>
                       <v-expansion-panel-header>生徒同士を近づける</v-expansion-panel-header>
                       <v-expansion-panel-content>
-                        <!-- 近づける生徒の入力フォーム（初期表示のための１つ目） -->
-                        <div>
+                        <!-- 近づける生徒の入力フォーム -->
+                        <div v-for="(nearCondition, nearIndex) in nearConditions">
                           <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setNearConditionOption1"></v-select>
+                          v-model="nearConditions[nearIndex][0]"></v-select>
                           と
                           <v-select :items="studentsName" placeholder="Bさん" outlined style="width:200px; display: inline-block"
-                          @change="setNearConditionOption2"></v-select>
+                          v-model="nearConditions[nearIndex][1]"></v-select>
                           の間を
                           <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addNearConditions"></v-select>
-                          以下にする
-                        </div>
-                        <!-- 近づける生徒の入力フォーム（追加表示のための２つ目以降） -->
-                        <div v-for="nearCondition in nearConditions">
-                          <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setNearConditionOption1"></v-select>
-                          と
-                          <v-select :items="studentsName" placeholder="Bさん" outlined style="width:200px; display: inline-block"
-                          @change="setNearConditionOption2"></v-select>
-                          の間を
-                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addNearConditions"></v-select>
+                          v-model="nearConditions[nearIndex][2]" @change.once="createNewNearConditions"></v-select>
                           以下にする
                         </div>
                       </v-expansion-panel-content>
@@ -247,28 +203,16 @@
                     <v-expansion-panel>
                       <v-expansion-panel-header>生徒同士を離す</v-expansion-panel-header>
                       <v-expansion-panel-content>
-                        <!-- 離す生徒の入力フォーム（初期表示のための１つ目） -->
-                        <div>
+                        <!-- 離す生徒の入力フォーム -->
+                        <div v-for="(farCondition, farIndex) in farConditions">
                           <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setFarConditionOption1"></v-select>
+                          v-model="farConditions[farIndex][0]"></v-select>
                           と
                           <v-select :items="studentsName" placeholder="Bさん" outlined style="width:200px; display: inline-block"
-                          @change="setFarConditionOption2"></v-select>
+                          v-model="farConditions[farIndex][1]"></v-select>
                           の間を
                           <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addFarConditions"></v-select>
-                          以上にする
-                        </div>
-                        <!-- 離す生徒の入力フォーム（追加表示のための２つ目以降） -->
-                        <div v-for="farCondition in farConditions">
-                          <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="setFarConditionOption1"></v-select>
-                          と
-                          <v-select :items="studentsName" placeholder="Bさん" outlined style="width:200px; display: inline-block"
-                          @change="setFarConditionOption2"></v-select>
-                          の間を
-                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                          @change="addFarConditions"></v-select>
+                          v-model="farConditions[farIndex][2]" @change.once="createNewFarConditions"></v-select>
                           以上にする
                         </div>
                       </v-expansion-panel-content>
@@ -448,28 +392,28 @@
           distanceOptions: [1,2,3,4,5,6,7,8], // 近づける・離す距離の選択肢
           studentsName: [], // 生徒の名前配列、席替えボタンが2回以上押されたときに元の生徒名を記憶しておくため
           dupStudentsName: [], // 生徒の名前配列の複製、席替えの際に破壊的にデータを取り出していく
-          nearConditions: [], // 近づける条件配列
+          nearConditions: [['', '', '']], // 近づける条件配列
           nearConditionOption1: '', // 近づける生徒1
           nearConditionOption2: '', // 近づける生徒2
           nearStudentsName: [], // 近づける生徒の名前
           dupNearStudentsName: [], // 近づける生徒の名前の複製
-          farConditions: [], // 離す条件
+          farConditions: [['', '', '']], // 離す条件用配列
           farConditionOption1: '', // 離す生徒1
           farConditionOption2: '', // 離す生徒2
           farStudentsName: [], // 離す生徒の名前
           dupFarStudentsName: [], // 離す生徒の名前の複製
           nearFarStudentsName: [], // 近づける/離す生徒の名前
           dupNearFarStudentsName: [], // 近づける/離す生徒の名前の複製
-          frontConditions: [], // 最前列に固定する生徒
+          frontConditions: [''], // 最前列に固定する生徒
           frontSeatsIndex: [], // 最前列のインデックス
           dupFrontSeatsIndex: [], // 最前列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
-          frontTwoRowsConditions: [], // 前2列に固定する生徒
+          frontTwoRowsConditions: [''], // 前2列に固定する生徒
           frontTwoRowsSeatsIndex: [], // 前2列のインデックス
           dupFrontTwoRowsSeatsIndex: [], // 前2列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
-          backConditions: [], // 最後列に固定する生徒
+          backConditions: [''], // 最後列に固定する生徒
           backSeatsIndex: [], // 最後列のインデックス
           dupBackSeatsIndex: [], // 最前列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
-          backTwoRowsConditions: [], // 後ろ2列に固定する生徒
+          backTwoRowsConditions: [''], // 後ろ2列に固定する生徒
           backTwoRowsSeatsIndex: [], // 後ろ2列のインデックス
           dupBackTwoRowsSeatsIndex: [], // 後ろ2列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
           nextSeatsTable: [], // 席替え後の座席テーブル
@@ -480,19 +424,40 @@
           genderArray: [], // 生徒の性別配列、テーブルを展開したもの、studentsName[]と順番が対応
           isAllDifferent: true, // 前回の座席と異なる配置にするかどうかの制御フラグ
           isFixGender: true, // 性別を固定するかどうかの制御フラグ
-          fixConditions: [], // 近づける条件配列
+          fixConditions: [['', '', '']], // 近づける条件配列
           fixConditionOption1: '', // 近づける生徒1
           fixConditionOption2: '', // 近づける生徒2
         },
         methods: {
           testMethod() { // デバッグ用。最後に消す。
-            let testArray1 = ["aaa", "bbb", "ccc"]
-            let testArray2 = [[0,0], [1,1], [2,2]]
+            let testArray1 = ["aaa", "bbb", "ccc", '']
 
-            console.log(testArray1.originalIndexOf("ccc"))
-            console.log(testArray2.originalIndexOf([1,2]))
+            console.log(testArray1);
+            testArray1 = testArray1.filter(Boolean);
+            console.log(testArray1);
 
             console.log('---------')
+          },
+          createNewNearConditions(){
+            this.nearConditions.push(['', '', '']);
+          },
+          createNewFarConditions(){
+            this.farConditions.push(['', '', '']);
+          },
+          createNewFixConditions(){
+            this.fixConditions.push(['', '', '']);
+          },
+          createNewFrontConditions(){
+            this.frontConditions.push('');
+          },
+          createNewFrontTwoRowsConditions(){
+            this.frontTwoRowsConditions.push('');
+          },
+          createNewBackTwoRowsConditions(){
+            this.backTwoRowsConditions.push('');
+          },
+          createNewBackConditions(){
+            this.backConditions.push('');
           },
           /*getColorByIndex(col, row) { // 座席の種類に応じた色を返す
             if(this.genderTable[row][col] === '') {
@@ -613,6 +578,10 @@
               this.makeFrontTwoRowsSeatsIndex(); // 前2列インデックスを作成
               this.makeBackSeatsIndex(); // 最後列インデックスを作成
               this.makeBackTwoRowsSeatsIndex(); // 後ろ2列インデックスを作成
+              this.frontConditions = this.frontConditions.filter(Boolean); // 空白を削除
+              this.frontTwoRowsConditions = this.frontTwoRowsConditions.filter(Boolean); // 空白を削除
+              this.backConditions = this.backConditions.filter(Boolean); // 空白を削除
+              this.backTwoRowsConditions = this.backTwoRowsConditions.filter(Boolean); // 空白を削除
               this.dupSeatsTableIndex = this.seatsTableIndex.slice(0); // 有効な座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupFrontSeatsIndex = this.frontSeatsIndex.slice(0); // 最前列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupFrontTwoRowsSeatsIndex = this.frontTwoRowsSeatsIndex.slice(0); // 前2列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
@@ -633,6 +602,11 @@
               //this.changeFarSeats(); // 離す生徒を席替え
               this.changeNearFarSeats(); // 近づける/離す生徒を席替え
               this.shuffleSeats(); // 条件のない生徒を席替え
+
+              this.createNewFrontConditions(); // 次回の準備、最前列のフォームを1つ作成
+              this.createNewFrontTwoRowsConditions(); // 次回の準備、前2列のフォームを1つ作成
+              this.createNewBackTwoRowsConditions(); // 次回の準備、後2列のフォームを1つ作成
+              this.createNewBackConditions(); // 次回の準備、最後列のフォームを1つ作成
               console.log(`----${loopNum}回目のループ終了----`);
             } while(this.restartFlag && loopNum <= 100)
             console.log(`====終了====`);
@@ -727,6 +701,7 @@
               this.delete(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
               this.delete(frontStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
               this.delete(frontStudentName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
+              this.delete(topIndex, this.dupFrontTwoRowsSeatsIndex); // ここで配置した座標はchangeFrontTwoRowsSeats()で使えないため、座席座標を削除する
             })
           },
           changeFrontTwoRowsSeats() { // 前2列に固定する生徒を席替え
@@ -769,6 +744,7 @@
               this.delete(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
               this.delete(backStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
               this.delete(backStudentName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
+              this.delete(topIndex, this.dupBackTwoRowsSeatsIndex); // ここで配置した座標はchangeBackTwoRowsSeats()で使えないため、座席座標を削除する
             })
           },
           changeBackTwoRowsSeats() { // 後ろ2列に固定する生徒を席替え
@@ -875,15 +851,17 @@
           },
           placeFixedSeats() { // 固定する生徒を配置
             this.fixConditions.forEach(fixCondition => {
-              let fixConditionName = fixCondition[0];
-              let fixConditionRow = fixCondition[1]-1; // 入力された値とインデックスのずれを補正
-              let fixConditionCol = fixCondition[2]-1; // 入力された値とインデックスのずれを補正
-              this.nextSeatsTable[fixConditionRow].splice(fixConditionCol, 1, fixConditionName); // 固定する場所に配置
+              if(fixCondition[0] != ''){ // フォーム表示のため最後に['', '', '']が入ってしまっているので、そのときは処理しない
+                let fixConditionName = fixCondition[0];
+                let fixConditionRow = fixCondition[1]-1; // 入力された値とインデックスのずれを補正
+                let fixConditionCol = fixCondition[2]-1; // 入力された値とインデックスのずれを補正
+                this.nextSeatsTable[fixConditionRow].splice(fixConditionCol, 1, fixConditionName); // 固定する場所に配置
 
-              let fixIndex = [fixConditionCol, fixConditionRow]
-              this.delete(fixIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
-              this.delete(fixConditionName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
-              this.delete(fixConditionName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
+                let fixIndex = [fixConditionCol, fixConditionRow]
+                this.delete(fixIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
+                this.delete(fixConditionName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
+                this.delete(fixConditionName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
+              }
             })
           },
           minDistance(p1, p2) { // 2点の距離のminを返す。p1, p2は座標、たとえばp1=[1,2]
@@ -988,6 +966,15 @@
             },
             deep: true
           },
+          /*
+          frontConditions: {
+            handler: function(){
+              this.frontConditions = this.frontConditions.filter(function(frontConditions) { //空白を削除
+                return frontConditions !== '';
+              })
+            }
+          },
+          */
           nearConditions: {
             handler: function(){
               this.nearStudentsName.splice(-this.nearStudentsName.length); // 配列を初期化
@@ -995,6 +982,9 @@
                 this.nearStudentsName.push(nearCondition[0], nearCondition[1]);
               })
               this.nearStudentsName = Array.from(new Set(this.nearStudentsName)) // 重複している名前を削除
+              this.nearStudentsName = this.nearStudentsName.filter(function(nearStudentsName) { //空白を削除
+                return nearStudentsName !== '';
+              })
             }
           },
           farConditions: {
@@ -1004,6 +994,9 @@
                 this.farStudentsName.push(farCondition[0], farCondition[1]);
               })
               this.farStudentsName = Array.from(new Set(this.farStudentsName)) // 重複している名前を削除
+              this.farStudentsName = this.farStudentsName.filter(function(farStudentsName) { //空白を削除
+                return farStudentsName !== '';
+              })
             }
           },
           genderTable: {

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
           <v-row>
             <!-- タイトル -->
             <v-col cols="12" style="background-color: wheat">
-              <h1 class="text-center">席替えメーカー（実装16日目）</h1>
+              <h1 class="text-center">席替えメーカー（実装17日目）</h1>
             </v-col>
           </v-row>
 
@@ -331,7 +331,6 @@
         },
         methods: {
           testMethod() { // デバッグ用。最後に消す。
-            this.toggleGender(this.genderTable, 0, 1);
             console.log('---------')
           },
           /*getColorByIndex(col, row) { // 座席の種類に応じた色を返す
@@ -377,12 +376,6 @@
             for(let i = 0; i < this.seatsSizeY; i++) {
               this.seatsTable.push( Array(this.seatsSizeX).fill('') ) // すべての席に名前が未入力な状態でテーブルを作成
             }
-            /* テストのため始めから入力
-            this.seatsTable.splice(0, 1, ['菊本さん', '', '', '', '大地さん', '']);
-            this.seatsTable.splice(1, 1, ['', '', 'たかこ\nさん', '', '', '']);
-            this.seatsTable.splice(2, 1, ['', '廣瀬さん', '', '', 'ののか\nさん', '']);
-            this.seatsTable.splice(3, 1, ['', '', '', '平尾さん', '', 'かんぬ\nさん']);
-             ここまで */
             this.countSeats();
           },
           countSeats() { // 有効な座席数をカウント
@@ -425,11 +418,11 @@
               this.nextSeatsTable.splice(i, 1, Array(this.seatsSizeX).fill(''));
             }
           },
-          changeSeats() { // 席替え処理
+          changeSeats() { // メイン処理
             let loopNum = 0; // changeSeats()の処理を指定された回数繰り返す際に制御する変数
             do {
               loopNum += 1;
-              console.log(`${loopNum}回目のループを開始します`);
+              console.log(`----${loopNum}回目のループを開始します----`);
               this.restartFlag = false;
               this.calcNum = 0 // エラー用計算量を初期化
               this.resetNextSeatsTable(); // 席替え後座席テーブルを初期化する
@@ -447,8 +440,9 @@
               //this.changeFarSeats(); // 離す生徒を席替え
               this.changeNearFarSeats(); // 近づける/離す生徒を席替え
               this.shuffleSeats(); // 条件のない生徒を席替え
-              console.log('---------------');
+              console.log(`----${loopNum}回目のループ終了----`);
             } while(this.restartFlag && loopNum <= 100)
+            console.log(`====終了====`);
             if(loopNum > 100){
               window.alert('条件を満たす席替えを実現できませんでした。\n何回か試してもエラーが出るようでしたら、条件を変更してください。');
             }
@@ -460,6 +454,17 @@
             this.shuffle(this.dupSeatsTableIndex); // インデックスをシャッフル
             this.dupStudentsName.forEach(dupStudentName => { // 生徒を一人取り出す
               let topIndex = this.dupSeatsTableIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
+              while( this.isFixGender && !this.checkGender(dupStudentName, topIndex) ){ // 征伐の条件を満たさない間、繰り返す
+                if(this.calcNum > this.seatsNum){
+                  // window.alert('条件を満たす席替えを実現できませんでした。\n何回か試してもエラーが出るようでしたら、条件を変更してください。');
+                  // throw '計算量が100を超えました'
+                  this.restartFlag = true;
+                  break;
+                }
+                this.dupSeatsTableIndex.push(topIndex); // 取り出したインデックスを配列の最後にプッシュして
+                topIndex = this.dupSeatsTableIndex.shift(); // 配列先頭のインデックスを再度取り出す
+                this.calcNum += 1;
+              }
               this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, dupStudentName); // 取り出したインデックスの位置に生徒名を保存
             })
           },
@@ -482,16 +487,16 @@
             this.shuffle(this.dupFrontSeatsIndex);
             this.frontConditions.forEach(frontStudentName => {
               let topIndex = this.dupFrontSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
-              //console.log(`${frontStudentName} を ${topIndex} に入れるのは ${this.checkNear(frontStudentName, topIndex)} (while内${this.calcNum}回目の計算)`);
               /* ----近づける/離す処理---- */
-              while( !this.checkNear(frontStudentName, topIndex) || !this.checkFar(frontStudentName, topIndex) ){ // どちらかの条件を満たさない間、繰り返す
-                if(this.calcNum > 100){
-                  window.alert('条件を満たす席替えを実現できませんでした。\n何回か試してもエラーが出るようでしたら、条件を変更してください。');
-                  throw '計算量が100を超えました'
+              while( !this.checkNear(frontStudentName, topIndex) || !this.checkFar(frontStudentName, topIndex) || ( this.isFixGender && !this.checkGender(frontStudentName, topIndex)) ){ // どちらかの条件を満たさない間、繰り返す
+                if(this.calcNum > this.seatsNum){
+                  // window.alert('条件を満たす席替えを実現できませんでした。\n何回か試してもエラーが出るようでしたら、条件を変更してください。');
+                  // throw '計算量が100を超えました'
+                  this.restartFlag = true;
+                  break;
                 }
                 this.dupFrontSeatsIndex.push(topIndex); // 取り出したインデックスを配列の最後にプッシュして
                 topIndex = this.dupFrontSeatsIndex.shift(); // 配列先頭のインデックスを再度取り出す
-                //console.log(`${frontStudentName} を ${topIndex} に入れるのは ${this.checkNear(frontStudentName, topIndex)} (while内${this.calcNum}回目の計算)`);
                 this.calcNum += 1;
               }
               /* ----ここまで---- */
@@ -517,6 +522,7 @@
               if(deleteNearFarStudentNameIndex != -1){ // dupNearFarStudentsNameにあれば削除する
                 this.dupNearFarStudentsName.splice(deleteNearFarStudentNameIndex, 1); // dupNearFarStudentsNameから削除する
               }
+              // console.log(`${frontStudentName}を配置した`)
             })
           },
           /*
@@ -584,7 +590,7 @@
               let topIndex = this.dupSeatsTableIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
               //console.log(`${dupNearStudentName} を ${topIndex} に入れるのは ${this.checkNear(dupNearStudentName, topIndex)} (${this.calcNum}回目の計算)`);
               /* ----近づける/離す処理---- */
-              while( !this.checkNear(dupNearFarStudentName, topIndex) || !this.checkFar(dupNearFarStudentName, topIndex) ){ // どちらかの条件を満たさない間、繰り返す
+              while( !this.checkNear(dupNearFarStudentName, topIndex) || !this.checkFar(dupNearFarStudentName, topIndex) || (this.isFixGender && !this.checkGender(dupNearFarStudentName, topIndex)) ){ // どちらかの条件を満たさない間、繰り返す
                 if(this.calcNum > this.seatsNum){
                   //window.alert('条件を満たす席替えを実現できませんでした。\n何回か試してもエラーが出るようでしたら、条件を変更してください。');
                   this.restartFlag = true;
@@ -601,7 +607,7 @@
 
               let deleteStudentNameIndex = this.dupStudentsName.indexOf(dupNearFarStudentName); // changeNearSeats()で配置した生徒は、shuffleSeats()で配置する必要がないため
               this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
-              console.log(`${dupNearFarStudentName}を配置した`)
+              // console.log(`${dupNearFarStudentName}を配置した`)
             })
           },
           resetFrontSeatsIndex() { // 最前列インデックス配列を空にする
@@ -662,6 +668,16 @@
               }
             })
             return return_value;
+          },
+          checkGender(studentName, p) { // 引数の生徒を座標pに配置しても、性別の条件を満たすならtrue、満たさないならfalseを返す
+            let genderIndex = this.studentsName.indexOf(studentName);
+            let currentGender = this.genderArray[genderIndex]; // 引数の生徒の性別
+            let nextGender = this.genderTable[p[1]][p[0]]; // 性別テーブルに記憶している性別
+            if(currentGender === nextGender){
+              return true
+            }else{
+              return false
+            }
           },
           getPositionFromNextSeatsTable(studentName) { // 引数の生徒が席替え後座席テーブルにすでにいればその座標を、いなければfalseを返す
             let nextSeatsRowNum = 0; // 行インデックス、y座標

--- a/index.html
+++ b/index.html
@@ -14,6 +14,12 @@
       .on-seats {
         background: mediumaquamarine;
       }
+      .male-seats {
+        background: lightskyblue;
+      }
+      .female-seats {
+        background: plum;
+      }
       .off-seats {
         background: gainsboro;
       }
@@ -37,22 +43,23 @@
           <v-row>
             <!-- タイトル -->
             <v-col cols="12" style="background-color: wheat">
-              <h1 class="text-center">席替えメーカー（実装15日目）</h1>
+              <h1 class="text-center">席替えメーカー（実装16日目）</h1>
             </v-col>
           </v-row>
 
           <v-row>
             <!-- 座席テーブル -->
-            <v-col cols="6" style="background-color: lightskyblue">
+            <v-col cols="6" style="background-color: #c8fac8">
               <p style="text-align: center">生徒の名前を入力してください</p>
               <p style="text-align: center">現在の座席に名前を入力することで、全員移動させることもできます</p>
+              <p style="text-align: center">クリックで性別を変更できます</p>
               <div id="seatArrange">
                 <li v-for="( seats, indexRow ) in seatsTable">
-                  <textarea v-for="( seat, indexCol ) in seats" :class="getColor( seatsTable[indexRow][indexCol] )"
+                  <textarea v-for="( seat, indexCol ) in seats" :class="getColorByName(seatsTable[indexRow][indexCol])"
                   class="seat" @input="writeStudentName( indexCol, indexRow, $event.target.value ); countSeats();"
                   @input.once="pushSeatsTableIndex(indexCol, indexRow);"
                   :key="indexRow.toString() + indexCol.toString()" style="text-align: center;  resize: none; word-break: keep-all"
-                  :value="seatsTable[indexRow][indexCol]">
+                  :value="seatsTable[indexRow][indexCol]" @click="toggleGender(indexCol,indexRow)">
                   </textarea>
                 </li>
               </div>
@@ -74,7 +81,9 @@
 
                 <!-- 同じ席にしないかどうかのチェックボックス -->
                 <v-col cols="12" style="background-color: orange">
-                  <v-checkbox label="現在の座席と異なる座席にする" color="indigo darken-3" value="indigo darken-3"
+                  <v-checkbox label="現在の座席と異なる座席にする" color="indigo darken-3" v-model="isAllDifferent"
+                  hide-details></v-checkbox>
+                  <v-checkbox label="男女の座席を固定する" color="indigo darken-3" v-model="isFixGender"
                   hide-details></v-checkbox>
                 </v-col>
 
@@ -197,7 +206,7 @@
                 <p style="text-align: center">席替え後の座席</p>
                 <li v-for="( nextSeats, indexRow ) in nextSeatsTable">
                   <textarea v-for="( seat, indexCol ) in nextSeats" class="seat"
-                  :class="getColor( nextSeatsTable[indexRow][indexCol] )"
+                  :class="getColorByName(nextSeatsTable[indexRow][indexCol])"
                   :key="indexRow.toString() + indexCol.toString()" style="text-align: center;  resize: none; word-break: keep-all"
                   :value="nextSeatsTable[indexRow][indexCol]">
                   </textarea>
@@ -261,6 +270,14 @@
                   <p>生徒の名前用配列の複製</p>
                   {{ dupStudentsName }}
                 </v-col>
+                <v-col cols="6" style="background-color: aliceblue">
+                  <p>性別用テーブル</p>
+                  <p v-for="seats in genderTable">{{ seats }}</p>
+                </v-col>
+                <v-col cols="6" style="background-color: #faf2c8">
+                  <p>性別用配列</p>
+                  {{ genderArray }}
+                </v-col>
               </v-row>
             </v-col>
           </v-row>
@@ -306,15 +323,54 @@
           frontSeatsIndex: [], // 最前列のインデックス
           dupFrontSeatsIndex: [], // 最前列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
           calcNum: 0, // 計算回数、無限ループに入ったときに抜け出す用
-          restartFlag: false // 条件を満たしていないとき、changeSeats()の最初からリスタートする制御用フラグ
+          restartFlag: false, // 条件を満たしていないとき、changeSeats()の最初からリスタートする制御用フラグ
+          genderTable: [], // 生徒の性別テーブル
+          genderArray: [], // 生徒の性別配列、テーブルを展開したもの、studentsName[]と順番が対応
+          isAllDifferent: true, // 前回の座席と異なる配置にするかどうかの制御フラグ
+          isFixGender: true, // 性別を固定するかどうかの制御フラグ
         },
         methods: {
-          getColor(seat) { // 座席の種類に応じた色を返す
-            if (seat === '') return 'off-seats'
-            else return 'on-seats'
+          testMethod() { // デバッグ用。最後に消す。
+            this.toggleGender(this.genderTable, 0, 1);
+            console.log('---------')
+          },
+          /*getColorByIndex(col, row) { // 座席の種類に応じた色を返す
+            if(this.genderTable[row][col] === '') {
+              return 'off-seats'
+            }else if(this.genderTable[row][col] === 'male'){
+              return 'male-seats'
+            }else if(this.genderTable[row][col] === 'female'){
+              return 'female-seats'
+            }else return 'on-seats'
+          },*/
+          getColorByName(studentName) { // 座席の種類に応じた色を返す
+            let genderIndex = this.studentsName.indexOf(studentName); // 生徒名に対応する性別を取得
+            let gender
+            if(genderIndex === -1){ //
+              gender = ''
+            }else{
+              gender = this.genderArray[genderIndex];
+            }
+            if(gender === '') {
+              return 'off-seats'
+            }else if(gender === 'male'){
+              return 'male-seats'
+            }else if(gender === 'female'){
+              return 'female-seats'
+            }else return 'on-seats'
+          },
+          toggleGender(col, row) {
+            if(this.genderTable[row][col] === 'male'){
+              this.genderTable[row].splice(col, 1, 'female')
+            }else if(this.genderTable[row][col] === 'female'){
+              this.genderTable[row].splice(col, 1, 'male')
+            }
           },
           writeStudentName(indexCol, indexRow, name) { // 引数で受け取った座席の有効・無効を切り替える
             this.seatsTable[indexRow].splice(indexCol, 1, name)
+            if(this.genderTable[indexRow][indexCol] === ''){
+              this.genderTable[indexRow].splice(indexCol, 1, 'male')
+            }
           },
           makeSeatsTable() { // seatsTableを作成
             this.seatsTable = []
@@ -561,9 +617,6 @@
             let y_abs = Math.abs( p1[1] - p2[1] );
             return Math.max(x_abs, y_abs);
           },
-          testMethod() { // デバッグ用。最後に消す。
-            console.log('---------')
-          },
           checkNear(studentName, p) { // 引数の生徒を座標pに配置しても、近づける条件を満たすならtrue、満たさないならfalseを返す
             let return_value = true
             this.nearConditions.forEach(nearConditionArray => {
@@ -622,10 +675,17 @@
             })
             return return_value;
           },
+          makeGenderTable() { // genderTableを作成
+            this.genderTable = []
+            for(let i = 0; i < this.seatsSizeY; i++) {
+              this.genderTable.push( Array(this.seatsSizeX).fill('') ) // すべての席に性別が未入力な状態でテーブルを作成
+            }
+          },
         },
         mounted() {
           this.makeSeatsTable() // 最初にseatsTableを作成
           this.makeNextSeatsTable() // 席替え後用のnextSeatsTableを空白で作成
+          this.makeGenderTable() // genderTableを作成
         },
         watch: {
           seatsTable: {
@@ -654,7 +714,16 @@
               })
               this.farStudentsName = Array.from(new Set(this.farStudentsName)) // 重複している名前を削除
             }
-          }
+          },
+          genderTable: {
+            handler: function(){
+              this.genderArray = Array.prototype.concat.apply([], this.genderTable); //genderTableを展開
+              this.genderArray = this.genderArray.filter(function(genderArray) { //空白を削除
+                return genderArray !== '';
+              })
+            },
+            deep: true
+          },
         }
       });
     </script>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
           <v-row>
             <!-- タイトル -->
             <v-col cols="12" style="background-color: wheat">
-              <h1 class="text-center">席替えメーカー（実装22日目）</h1>
+              <h1 class="text-center">席替えメーカー（実装23日目）</h1>
             </v-col>
           </v-row>
 
@@ -161,10 +161,10 @@
                           <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
                           v-model="fixConditions[fixIndex][0]"></v-select>
                           を、前から
-                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
+                          <v-select :items="limitedSeatsOptionsY" outlined style="width:70px; display: inline-block"
                           v-model="fixConditions[fixIndex][1]"></v-select>
                           列目、左から
-                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
+                          <v-select :items="limitedSeatsOptionsX" outlined style="width:70px; display: inline-block"
                           v-model="fixConditions[fixIndex][2]" @change.once="createNewFixConditions"></v-select>
                           列目に固定する
                         </div>
@@ -190,7 +190,7 @@
                           の間を
                           <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
                           v-model="nearConditions[nearIndex][2]" @change.once="createNewNearConditions"></v-select>
-                          以下にする
+                          席以下にする
                         </div>
                       </v-expansion-panel-content>
                     </v-expansion-panel>
@@ -213,7 +213,7 @@
                           の間を
                           <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
                           v-model="farConditions[farIndex][2]" @change.once="createNewFarConditions"></v-select>
-                          以上にする
+                          席以上空ける
                         </div>
                       </v-expansion-panel-content>
                     </v-expansion-panel>
@@ -389,17 +389,15 @@
           seatsNum: 0, // 有効な座席数
           seatsOptionsX: [1,2,3,4,5,6,7,8], // よこの座席数入力フォームの選択肢
           seatsOptionsY: [1,2,3,4,5,6,7,8], // たての座席数入力フォームの選択肢
-          distanceOptions: [1,2,3,4,5,6,7,8], // 近づける・離す距離の選択肢
+          limitedSeatsOptionsX: [1,2,3,4,5,6], // seatsSizeXのデフォルト値6に合わせて、選択肢のデフォルト値も6までにする
+          limitedSeatsOptionsY: [1,2,3,4,5,6], // seatsSizeYのデフォルト値6に合わせて、選択肢のデフォルト値も6までにする
+          distanceOptions: [0,1,2,3,4], // 近づける・離す距離の選択肢、デフォルト値6に合わせて実現可能な選択肢をデフォルトに設定
           studentsName: [], // 生徒の名前配列、席替えボタンが2回以上押されたときに元の生徒名を記憶しておくため
           dupStudentsName: [], // 生徒の名前配列の複製、席替えの際に破壊的にデータを取り出していく
           nearConditions: [['', '', '']], // 近づける条件配列
-          nearConditionOption1: '', // 近づける生徒1
-          nearConditionOption2: '', // 近づける生徒2
           nearStudentsName: [], // 近づける生徒の名前
           dupNearStudentsName: [], // 近づける生徒の名前の複製
           farConditions: [['', '', '']], // 離す条件用配列
-          farConditionOption1: '', // 離す生徒1
-          farConditionOption2: '', // 離す生徒2
           farStudentsName: [], // 離す生徒の名前
           dupFarStudentsName: [], // 離す生徒の名前の複製
           nearFarStudentsName: [], // 近づける/離す生徒の名前
@@ -425,8 +423,6 @@
           isAllDifferent: true, // 前回の座席と異なる配置にするかどうかの制御フラグ
           isFixGender: true, // 性別を固定するかどうかの制御フラグ
           fixConditions: [['', '', '']], // 近づける条件配列
-          fixConditionOption1: '', // 近づける生徒1
-          fixConditionOption2: '', // 近づける生徒2
         },
         methods: {
           testMethod() { // デバッグ用。最後に消す。
@@ -459,15 +455,6 @@
           createNewBackConditions(){
             this.backConditions.push('');
           },
-          /*getColorByIndex(col, row) { // 座席の種類に応じた色を返す
-            if(this.genderTable[row][col] === '') {
-              return 'off-seats'
-            }else if(this.genderTable[row][col] === 'male'){
-              return 'male-seats'
-            }else if(this.genderTable[row][col] === 'female'){
-              return 'female-seats'
-            }else return 'on-seats'
-          },*/
           getColorByName(studentName) { // 座席の種類に応じた色を返す
             let genderIndex = this.studentsName.indexOf(studentName); // 生徒名に対応する性別を取得
             let gender
@@ -511,45 +498,6 @@
                 if (seat !== '') this.seatsNum += 1
               })
             })
-          },
-          setNearConditionOption1(nearConditionOption1) { // 近づける条件で指定する生徒1を登録
-            this.nearConditionOption1 = nearConditionOption1;
-          },
-          setNearConditionOption2(nearConditionOption2) {　// 近づける条件で指定する生徒2を登録
-            this.nearConditionOption2 = nearConditionOption2;
-          },
-          addNearConditions(distance) { // 生徒1と生徒2を近づける条件を登録
-            this.nearConditions.push( [this.nearConditionOption1, this.nearConditionOption2, distance] );
-          },
-          setFarConditionOption1(farConditionOption1) { // 離す条件で指定する生徒1を登録
-            this.farConditionOption1 = farConditionOption1;
-          },
-          setFarConditionOption2(farConditionOption2) { // 離す条件で指定する生徒2を登録
-            this.farConditionOption2 = farConditionOption2;
-          },
-          addFarConditions(distance) { // 生徒1と生徒2を離す条件を登録
-            this.farConditions.push( [this.farConditionOption1, this.farConditionOption2, distance] )
-          },
-          addFrontConditions(studentName) { // 最前列に固定する条件を要録
-            this.frontConditions.push(studentName);
-          },
-          addFrontTwoRowsConditions(studentName) { // 前2列に固定する条件を要録
-            this.frontTwoRowsConditions.push(studentName);
-          },
-          addBackConditions(studentName) { // 最後列に固定する条件を要録
-            this.backConditions.push(studentName);
-          },
-          addBackTwoRowsConditions(studentName) { // 後ろ2列に固定する条件を要録
-            this.backTwoRowsConditions.push(studentName);
-          },
-          setFixConditionOption1(fixConditionOption1) { // 近づける条件で指定する生徒1を登録
-            this.fixConditionOption1 = fixConditionOption1;
-          },
-          setFixConditionOption2(fixConditionOption2) {　// 近づける条件で指定する生徒2を登録
-            this.fixConditionOption2 = fixConditionOption2;
-          },
-          addFixConditions(fixConditionOption3) { // 生徒1と生徒2を近づける条件を登録
-            this.fixConditions.push( [this.fixConditionOption1, this.fixConditionOption2, fixConditionOption3] );
           },
           makeNextSeatsTable() { // nextSeatsTableを作成
             this.nextSeatsTable = []
@@ -608,9 +556,9 @@
               this.createNewBackTwoRowsConditions(); // 次回の準備、後2列のフォームを1つ作成
               this.createNewBackConditions(); // 次回の準備、最後列のフォームを1つ作成
               console.log(`----${loopNum}回目のループ終了----`);
-            } while(this.restartFlag && loopNum <= 100)
+            } while(this.restartFlag && loopNum <= 500)
             console.log(`====終了====`);
-            if(loopNum > 100){
+            if(loopNum > 500){
               window.alert('条件を満たす席替えを実現できませんでした。\n何回か試してもエラーが出るようでしたら、条件を変更してください。');
             }
           },
@@ -861,6 +809,11 @@
                 this.delete(fixIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
                 this.delete(fixConditionName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
                 this.delete(fixConditionName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
+
+                this.delete(fixIndex, this.dupFrontSeatsIndex); // ここで配置した座標はchangeFrontSeats()で使えないため、座席座標を削除する
+                this.delete(fixIndex, this.dupFrontTwoRowsSeatsIndex); // ここで配置した座標はchangeFrontTwoRowsSeats()で使えないため、座席座標を削除する
+                this.delete(fixIndex, this.dupBackSeatsIndex); // ここで配置した座標はchangeBackSeats()で使えないため、座席座標を削除する
+                this.delete(fixIndex, this.dupBackTwoRowsSeatsIndex); // ここで配置した座標はchangeBackTwoRowsSeats()で使えないため、座席座標を削除する
               }
             })
           },
@@ -886,7 +839,7 @@
                   nearStudentName = nearConditionArray[0]; // 引数の生徒と近づけたい生徒
                 }
                 // ----ここまで----
-                let distance = nearConditionArray[2]; // 距離
+                let distance = nearConditionArray[2] + 1; // 距離、表記とのズレを修正するために+1
                 let nearStudentPosition = this.getPositionFromNextSeatsTable(nearStudentName); // すでに配置されていればその座標、まだ配置されてなければfalse
                 if( this.maxDistance(p, nearStudentPosition) > distance ){ // 距離のmaxが条件distanceより上なら返り値をfalseに更新
                   return_value = false;
@@ -907,7 +860,7 @@
                   farStudentName = farConditionArray[0]; // 引数の生徒と離す生徒
                 }
                 // ----ここまで----
-                let distance = farConditionArray[2]; // 距離
+                let distance = farConditionArray[2] + 1; // 距離、表記とのズレを修正するために+1
                 let farStudentPosition = this.getPositionFromNextSeatsTable(farStudentName); // すでに配置されていればその座標、まだ配置されてなければfalse
                 if( this.maxDistance(p, farStudentPosition) < distance ){ // 距離のminが条件distanceより下なら返り値をfalseに更新
                   return_value = false;
@@ -966,15 +919,6 @@
             },
             deep: true
           },
-          /*
-          frontConditions: {
-            handler: function(){
-              this.frontConditions = this.frontConditions.filter(function(frontConditions) { //空白を削除
-                return frontConditions !== '';
-              })
-            }
-          },
-          */
           nearConditions: {
             handler: function(){
               this.nearStudentsName.splice(-this.nearStudentsName.length); // 配列を初期化
@@ -1008,6 +952,20 @@
             },
             deep: true
           },
+          seatsSizeX: {
+            handler: function(){
+              this.limitedSeatsOptionsX = [...Array(this.seatsSizeX)].map((_, i) => i + 1);
+              const maxXY = Math.max(this.seatsSizeX, this.seatsSizeY);
+              this.distanceOptions = [...Array(maxXY-1)].map((_, i) => i)
+            }
+          },
+          seatsSizeY: {
+            handler: function(){
+              this.limitedSeatsOptionsY = [...Array(this.seatsSizeY)].map((_, i) => i + 1)
+              const maxXY = Math.max(this.seatsSizeX, this.seatsSizeY);
+              this.distanceOptions = [...Array(maxXY-1)].map((_, i) => i)
+            }
+          }
         }
       });
     </script>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
               <p style="text-align: center">名前を入力してください</p>
               <p style="text-align: center">現在の座席に名前を入力することで、全員移動させることもできます</p>
               <p style="text-align: center">クリックで性別を変更できます</p>
-              <div id="seatArrange">
+              <div>
                 <li v-for="( seats, indexRow ) in seatsTable">
                   <textarea v-for="( seat, indexCol ) in seats" :class="getColorByName(seatsTable[indexRow][indexCol])"
                   class="seat" @input="writeStudentName( indexCol, indexRow, $event.target.value ); countSeats();"
@@ -87,7 +87,7 @@
                   hide-details></v-checkbox>
                 </v-col>
 
-                <!-- 列で固定するエクスパンションパネル -->
+                <!-- 横の列で固定するエクスパンションパネル -->
                 <v-col cols="12" style="background-color: hotpink">
                   <v-expansion-panels accordion>
                     <v-expansion-panel>
@@ -168,6 +168,43 @@
                     </v-expansion-panel>
                   </v-expansion-panels>
                 </v-col>
+
+
+                <!-- 特定の席に固定する生徒のエクスパンションパネル -->
+                <v-col cols="12" style="background-color: #8fcccc">
+                  <v-expansion-panels accordion>
+                    <v-expansion-panel>
+                      <v-expansion-panel-header>特定の席に固定する</v-expansion-panel-header>
+                      <v-expansion-panel-content>
+                        <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
+                        <div>
+                          <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
+                          @change="setFixConditionOption1"></v-select>
+                          を、前から
+                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
+                          @change="setFixConditionOption2"></v-select>
+                          列目、左から
+                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
+                          @change="addFixConditions"></v-select>
+                          列目に固定する
+                        </div>
+                        <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
+                        <div v-for="fixCondition in fixConditions">
+                          <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
+                          @change="setFixConditionOption1"></v-select>
+                          を、前から
+                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
+                          @change="setFixConditionOption2"></v-select>
+                          列目、左から
+                          <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
+                          @change="addFixConditions"></v-select>
+                          列目に固定する
+                        </div>
+                      </v-expansion-panel-content>
+                    </v-expansion-panel>
+                  </v-expansion-panels>
+                </v-col>
+
 
                 <!-- 近づける生徒のエクスパンションパネル -->
                 <v-col cols="12" style="background-color: burlywood">
@@ -370,6 +407,10 @@
                   <p>性別用配列</p>
                   {{ genderArray }}
                 </v-col>
+                <v-col cols="6" style="background-color: plum">
+                  <p>固定する条件用配列</p>
+                  {{ fixConditions }}
+                </v-col>
               </v-row>
             </v-col>
           </v-row>
@@ -382,6 +423,16 @@
     <script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>
 
     <script>
+      Array.prototype.originalIndexOf = function(target) { // indexOf()は厳密比較を行うため、抽象比較を行うメソッドを定義
+        let indexNum = this.length;
+        let dupThis = this.slice(0); // reverse()は破壊的なので、引数を破壊しないために複製を作成
+        let temp = dupThis.reverse().some(array => {
+          indexNum -= 1;
+          return (array.toString() == target.toString());
+        })
+        if(!temp){ indexNum -= 1; } // 最後まで見つからなかったとき、返り値を-1にするための調整
+        return indexNum;
+      }
       const app = new Vue({
         el: "#app",
         vuetify: new Vuetify(),
@@ -429,9 +480,18 @@
           genderArray: [], // 生徒の性別配列、テーブルを展開したもの、studentsName[]と順番が対応
           isAllDifferent: true, // 前回の座席と異なる配置にするかどうかの制御フラグ
           isFixGender: true, // 性別を固定するかどうかの制御フラグ
+          fixConditions: [], // 近づける条件配列
+          fixConditionOption1: '', // 近づける生徒1
+          fixConditionOption2: '', // 近づける生徒2
         },
         methods: {
           testMethod() { // デバッグ用。最後に消す。
+            let testArray1 = ["aaa", "bbb", "ccc"]
+            let testArray2 = [[0,0], [1,1], [2,2]]
+
+            console.log(testArray1.originalIndexOf("ccc"))
+            console.log(testArray2.originalIndexOf([1,2]))
+
             console.log('---------')
           },
           /*getColorByIndex(col, row) { // 座席の種類に応じた色を返す
@@ -517,6 +577,15 @@
           addBackTwoRowsConditions(studentName) { // 後ろ2列に固定する条件を要録
             this.backTwoRowsConditions.push(studentName);
           },
+          setFixConditionOption1(fixConditionOption1) { // 近づける条件で指定する生徒1を登録
+            this.fixConditionOption1 = fixConditionOption1;
+          },
+          setFixConditionOption2(fixConditionOption2) {　// 近づける条件で指定する生徒2を登録
+            this.fixConditionOption2 = fixConditionOption2;
+          },
+          addFixConditions(fixConditionOption3) { // 生徒1と生徒2を近づける条件を登録
+            this.fixConditions.push( [this.fixConditionOption1, this.fixConditionOption2, fixConditionOption3] );
+          },
           makeNextSeatsTable() { // nextSeatsTableを作成
             this.nextSeatsTable = []
             for(let i = 0; i < this.seatsSizeY; i++) {
@@ -555,6 +624,7 @@
               this.dupNearFarStudentsName = this.nearStudentsName.concat(this.farStudentsName); // 近づける生徒名と離す生徒名を結合、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupNearFarStudentsName = Array.from(new Set(this.dupNearFarStudentsName)) // 重複している名前を削除
 
+              this.placeFixedSeats(); // 固定する生徒を配置
               this.changeFrontSeats(); // 最前列に固定する生徒を席替え
               this.changeBackSeats(); // 最後列に固定する生徒を席替え
               this.changeFrontTwoRowsSeats(); // 前2列に固定する生徒を席替え
@@ -574,13 +644,12 @@
             this.seatsTableIndex.push([indexCol, indexRow]);
           },
           shuffleSeats() { // 条件のない生徒を席替え
+            // console.log(`dupSeatsTableIndex = ${this.dupSeatsTableIndex}`)
             this.shuffle(this.dupSeatsTableIndex); // インデックスをシャッフル
             this.dupStudentsName.forEach(dupStudentName => { // 生徒を一人取り出す
               let topIndex = this.dupSeatsTableIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
               while( this.isFixGender && !this.checkGender(dupStudentName, topIndex) ){ // 征伐の条件を満たさない間、繰り返す
                 if(this.calcNum > this.seatsNum){
-                  // window.alert('条件を満たす席替えを実現できませんでした。\n何回か試してもエラーが出るようでしたら、条件を変更してください。');
-                  // throw '計算量が100を超えました'
                   this.restartFlag = true;
                   break;
                 }
@@ -884,6 +953,47 @@
               // console.log(`${dupNearFarStudentName}を配置した`)
             })
           },
+          placeFixedSeats() { // 固定する生徒を配置
+            this.fixConditions.forEach(fixCondition => {
+              let fixConditionName = fixCondition[0];
+              let fixConditionRow = fixCondition[1]-1; // 入力された値とインデックスのずれを補正
+              let fixConditionCol = fixCondition[2]-1; // 入力された値とインデックスのずれを補正
+              this.nextSeatsTable[fixConditionRow].splice(fixConditionCol, 1, fixConditionName); // 固定する場所に配置
+
+              let fixIndex = [fixConditionCol, fixConditionRow]
+
+              let deleteIndex = this.dupSeatsTableIndex.originalIndexOf(fixIndex); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
+              if(deleteIndex =! -1){
+                this.dupSeatsTableIndex.splice(deleteIndex, 1); // dupSeatsTableIndexから削除する
+              }
+
+              let deleteStudentNameIndex = this.dupStudentsName.indexOf(fixConditionName); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
+              this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
+
+              // todo frontIndexからも消す
+              let deleteFrontSeatsIndex = this.dupFrontSeatsIndex.originalIndexOf(fixIndex); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
+              if(deleteFrontSeatsIndex != -1){ // dupNearStudentsNameにあれば削除する
+                this.dupFrontSeatsIndex.splice(deleteFrontSeatsIndex, 1); // dupNearStudentsNameから削除する
+              }
+
+
+              let deleteNearStudentNameIndex = this.dupNearStudentsName.indexOf(fixConditionName); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
+              if(deleteNearStudentNameIndex != -1){ // dupNearStudentsNameにあれば削除する
+                this.dupNearStudentsName.splice(deleteNearStudentNameIndex, 1); // dupNearStudentsNameから削除する
+              }
+
+              let deleteFarStudentNameIndex = this.dupFarStudentsName.indexOf(fixConditionName); // ここで配置した生徒は、changeFarSeats()で配置する必要がないため
+              if(deleteFarStudentNameIndex != -1){ // dupFarStudentsNameにあれば削除する
+                this.dupFarStudentsName.splice(deleteFarStudentNameIndex, 1); // dupFarStudentsNameから削除する
+              }
+
+              let deleteNearFarStudentNameIndex = this.dupNearFarStudentsName.indexOf(fixConditionName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため
+              if(deleteNearFarStudentNameIndex != -1){ // dupNearFarStudentsNameにあれば削除する
+                this.dupNearFarStudentsName.splice(deleteNearFarStudentNameIndex, 1); // dupNearFarStudentsNameから削除する
+              }
+
+            })
+          },
           min_distance(p1, p2) { // 2点の距離のminを返す。p1, p2は座標、たとえばp1=[1,2]
             let x_abs = Math.abs( p1[0] - p2[0] );
             let y_abs = Math.abs( p1[1] - p2[1] );
@@ -967,7 +1077,7 @@
             for(let i = 0; i < this.seatsSizeY; i++) {
               this.genderTable.push( Array(this.seatsSizeX).fill('') ) // すべての席に性別が未入力な状態でテーブルを作成
             }
-          },
+          }
         },
         mounted() {
           this.makeSeatsTable() // 最初にseatsTableを作成

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
           <v-row>
             <!-- タイトル -->
             <v-col cols="12" style="background-color: wheat">
-              <h1 class="text-center">席替えメーカー（実装17日目）</h1>
+              <h1 class="text-center">席替えメーカー（実装20日目）</h1>
             </v-col>
           </v-row>
 
@@ -963,7 +963,7 @@
               let fixIndex = [fixConditionCol, fixConditionRow]
 
               let deleteIndex = this.dupSeatsTableIndex.originalIndexOf(fixIndex); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
-              if(deleteIndex =! -1){
+              if(deleteIndex != -1){
                 this.dupSeatsTableIndex.splice(deleteIndex, 1); // dupSeatsTableIndexから削除する
               }
 

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
           <v-row>
             <!-- 座席テーブル -->
             <v-col cols="6" style="background-color: #c8fac8">
-              <p style="text-align: center">生徒の名前を入力してください</p>
+              <p style="text-align: center">名前を入力してください</p>
               <p style="text-align: center">現在の座席に名前を入力することで、全員移動させることもできます</p>
               <p style="text-align: center">クリックで性別を変更できます</p>
               <div id="seatArrange">
@@ -67,15 +67,15 @@
 
             <v-col cols="6">
               <v-row>
-                <!-- よこの座席数入力フォーム -->
+                <!-- 横の座席数入力フォーム -->
                 <v-col cols="6" style="background-color: turquoise">
-                  <v-select :items="seatsOptionsX" label="よこの座席数" outlined　v-model.number="seatsSizeX"
+                  <v-select :items="seatsOptionsX" label="横の座席数" outlined　v-model.number="seatsSizeX"
                   @change="makeSeatsTable()" style="width:100px"></v-select>
                 </v-col>
 
-                <!-- たての座席数入力フォーム -->
+                <!-- 縦の座席数入力フォーム -->
                 <v-col cols="6" style="background-color: lightseagreen">
-                  <v-select :items="seatsOptionsY" label="たての座席数" outlined　v-model.number="seatsSizeY"
+                  <v-select :items="seatsOptionsY" label="縦の座席数" outlined　v-model.number="seatsSizeY"
                   @change="makeSeatsTable()" style="width:100px"></v-select>
                 </v-col>
 
@@ -87,21 +87,83 @@
                   hide-details></v-checkbox>
                 </v-col>
 
-                <!-- 最前列に固定する生徒のエクスパンションパネル -->
+                <!-- 列で固定するエクスパンションパネル -->
                 <v-col cols="12" style="background-color: hotpink">
                   <v-expansion-panels accordion>
                     <v-expansion-panel>
-                      <v-expansion-panel-header>最前列に固定する生徒を入力する</v-expansion-panel-header>
+                      <v-expansion-panel-header>横の列で固定する</v-expansion-panel-header>
                       <v-expansion-panel-content>
-                        <!-- 最前列に固定する生徒の入力フォーム（初期表示のための１つ目） -->
-                        <span>
-                          <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="addFrontConditions"></v-select>
-                        </span>
-                        <span v-for="frontCondition in frontConditions">
-                          <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
-                          @change="addFrontConditions"></v-select>
-                        </span>
+                        <!-- ネストされたエクスパンションパネル -->
+                        <v-expansion-panels accordion>
+                          <!-- 最前列のエクスパンションパネル -->
+                          <v-expansion-panel>
+                            <v-expansion-panel-header>最前列</v-expansion-panel-header>
+                            <v-expansion-panel-content>
+                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
+                              <span>
+                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
+                                @change="addFrontConditions"></v-select>
+                              </span>
+                              <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
+                              <span v-for="frontCondition in frontConditions">
+                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
+                                @change="addFrontConditions"></v-select>
+                              </span>
+                            </v-expansion-panel-content>
+                          </v-expansion-panel>
+
+                          <!-- 前2列のエクスパンションパネル -->
+                          <v-expansion-panel>
+                            <v-expansion-panel-header>前2列</v-expansion-panel-header>
+                            <v-expansion-panel-content>
+                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
+                              <span>
+                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
+                                @change="addFrontTwoRowsConditions"></v-select>
+                              </span>
+                              <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
+                              <span v-for="frontTwoRowsCondition in frontTwoRowsConditions">
+                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
+                                @change="addFrontTwoRowsConditions"></v-select>
+                              </span>
+                            </v-expansion-panel-content>
+                          </v-expansion-panel>
+
+                          <!-- 後ろ2列のエクスパンションパネル -->
+                          <v-expansion-panel>
+                            <v-expansion-panel-header>後ろ2列</v-expansion-panel-header>
+                            <v-expansion-panel-content>
+                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
+                              <span>
+                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
+                                @change="addBackTwoRowsConditions"></v-select>
+                              </span>
+                              <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
+                              <span v-for="backTwoRowsCondition in backTwoRowsConditions">
+                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
+                                @change="addBackTwoRowsConditions"></v-select>
+                              </span>
+                            </v-expansion-panel-content>
+                          </v-expansion-panel>
+
+                          <!-- 最後列のエクスパンションパネル -->
+                          <v-expansion-panel>
+                            <v-expansion-panel-header>最後列</v-expansion-panel-header>
+                            <v-expansion-panel-content>
+                              <!-- 生徒の入力フォーム（初期表示のための１つ目） -->
+                              <span>
+                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
+                                @change="addBackConditions"></v-select>
+                              </span>
+                              <!-- 生徒の入力フォーム（追加表示のための２つ目以降） -->
+                              <span v-for="backCondition in backConditions">
+                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:200px; display: inline-block"
+                                @change="addBackConditions"></v-select>
+                              </span>
+                            </v-expansion-panel-content>
+                          </v-expansion-panel>
+
+                        </v-expansion-panels>
                       </v-expansion-panel-content>
                     </v-expansion-panel>
                   </v-expansion-panels>
@@ -111,7 +173,7 @@
                 <v-col cols="12" style="background-color: burlywood">
                   <v-expansion-panels accordion>
                     <v-expansion-panel>
-                      <v-expansion-panel-header>近づける生徒を入力する</v-expansion-panel-header>
+                      <v-expansion-panel-header>生徒同士を近づける</v-expansion-panel-header>
                       <v-expansion-panel-content>
                         <!-- 近づける生徒の入力フォーム（初期表示のための１つ目） -->
                         <div>
@@ -146,7 +208,7 @@
                 <v-col cols="12" style="background-color: lightgreen">
                   <v-expansion-panels accordion>
                     <v-expansion-panel>
-                      <v-expansion-panel-header>離す生徒を入力する</v-expansion-panel-header>
+                      <v-expansion-panel-header>生徒同士を離す</v-expansion-panel-header>
                       <v-expansion-panel-content>
                         <!-- 離す生徒の入力フォーム（初期表示のための１つ目） -->
                         <div>
@@ -226,11 +288,35 @@
                   <p>有効な座席のインデックス配列の複製</p>
                   {{ dupSeatsTableIndex }}
                 </v-col>
+                <v-col cols="6" style="background-color: paleturquoise">
+                  <p>生徒の名前用配列</p>
+                  {{ studentsName }}
+                  <p>生徒の名前用配列の複製</p>
+                  {{ dupStudentsName }}
+                </v-col>
                 <v-col cols="6" style="background-color: lightsteelblue">
                   <p>最前列の座席のインデックス配列</p>
                   {{ frontSeatsIndex }}
                   <p>最前列の座席のインデックス配列の複製</p>
                   {{ dupFrontSeatsIndex }}
+                </v-col>
+                <v-col cols="6" style="background-color: #edbee6">
+                  <p>最後列の座席のインデックス配列</p>
+                  {{ backSeatsIndex }}
+                  <p>最後列の座席のインデックス配列の複製</p>
+                  {{ dupBackSeatsIndex }}
+                </v-col>
+                <v-col cols="6" style="background-color: #ede7d5">
+                  <p>前2列の座席のインデックス配列</p>
+                  {{ frontTwoRowsSeatsIndex }}
+                  <p>前2列の座席のインデックス配列の複製</p>
+                  {{ dupFrontTwoRowsSeatsIndex }}
+                </v-col>
+                <v-col cols="6" style="background-color: #a3cccc">
+                  <p>後ろ2列の座席のインデックス配列</p>
+                  {{ backTwoRowsSeatsIndex }}
+                  <p>後ろ2列の座席のインデックス配列の複製</p>
+                  {{ dupBackTwoRowsSeatsIndex }}
                 </v-col>
                 <v-col cols="6"  style="background-color: lightsalmon">
                   <div>
@@ -264,11 +350,17 @@
                   <p>最前列に固定する生徒</p>
                   {{ frontConditions }}
                 </v-col>
-                <v-col cols="6" style="background-color: paleturquoise">
-                  <p>生徒の名前用配列</p>
-                  {{ studentsName }}
-                  <p>生徒の名前用配列の複製</p>
-                  {{ dupStudentsName }}
+                <v-col cols="6" style="background-color: #b1a6ed">
+                  <p>最後列に固定する生徒</p>
+                  {{ backConditions }}
+                </v-col>
+                <v-col cols="6" style="background-color: #ede7d5">
+                  <p>前2列に固定する生徒</p>
+                  {{ frontTwoRowsConditions }}
+                </v-col>
+                <v-col cols="6" style="background-color: #a3cccc">
+                  <p>後ろ2列に固定する生徒</p>
+                  {{ backTwoRowsConditions }}
                 </v-col>
                 <v-col cols="6" style="background-color: aliceblue">
                   <p>性別用テーブル</p>
@@ -297,6 +389,8 @@
           seatsSizeY: 6, // デフォルト値は6
           seatsSizeX: 6, // デフォルト値は6
           seatsTable: [], // 座席テーブル
+          seatsTableIndex: [], // 座席テーブル上の有効な座席のインデックス
+          dupSeatsTableIndex: [], // 座席テーブル上の有効な座席のインデックスの複製、席替えの際に破壊的にデータを取り出していく
           seatsNum: 0, // 有効な座席数
           seatsOptionsX: [1,2,3,4,5,6,7,8], // よこの座席数入力フォームの選択肢
           seatsOptionsY: [1,2,3,4,5,6,7,8], // たての座席数入力フォームの選択肢
@@ -316,12 +410,19 @@
           nearFarStudentsName: [], // 近づける/離す生徒の名前
           dupNearFarStudentsName: [], // 近づける/離す生徒の名前の複製
           frontConditions: [], // 最前列に固定する生徒
-          nextSeatsTable: [], // 席替え後の座席テーブル
-          tempRow: '', // 2次元配列をリアクティブに更新するために、2次元配列の要素である1次元配列を退避
-          seatsTableIndex: [], // 座席テーブル上の有効な座席のインデックス
-          dupSeatsTableIndex: [], // 座席テーブル上の有効な座席のインデックスの複製、席替えの際に破壊的にデータを取り出していく
           frontSeatsIndex: [], // 最前列のインデックス
           dupFrontSeatsIndex: [], // 最前列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
+          frontTwoRowsConditions: [], // 前2列に固定する生徒
+          frontTwoRowsSeatsIndex: [], // 前2列のインデックス
+          dupFrontTwoRowsSeatsIndex: [], // 前2列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
+          backConditions: [], // 最後列に固定する生徒
+          backSeatsIndex: [], // 最後列のインデックス
+          dupBackSeatsIndex: [], // 最前列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
+          backTwoRowsConditions: [], // 後ろ2列に固定する生徒
+          backTwoRowsSeatsIndex: [], // 後ろ2列のインデックス
+          dupBackTwoRowsSeatsIndex: [], // 後ろ2列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
+          nextSeatsTable: [], // 席替え後の座席テーブル
+          tempRow: '', // 2次元配列をリアクティブに更新するために、2次元配列の要素である1次元配列を退避
           calcNum: 0, // 計算回数、無限ループに入ったときに抜け出す用
           restartFlag: false, // 条件を満たしていないとき、changeSeats()の最初からリスタートする制御用フラグ
           genderTable: [], // 生徒の性別テーブル
@@ -407,6 +508,15 @@
           addFrontConditions(studentName) { // 最前列に固定する条件を要録
             this.frontConditions.push(studentName);
           },
+          addFrontTwoRowsConditions(studentName) { // 前2列に固定する条件を要録
+            this.frontTwoRowsConditions.push(studentName);
+          },
+          addBackConditions(studentName) { // 最後列に固定する条件を要録
+            this.backConditions.push(studentName);
+          },
+          addBackTwoRowsConditions(studentName) { // 後ろ2列に固定する条件を要録
+            this.backTwoRowsConditions.push(studentName);
+          },
           makeNextSeatsTable() { // nextSeatsTableを作成
             this.nextSeatsTable = []
             for(let i = 0; i < this.seatsSizeY; i++) {
@@ -427,15 +537,28 @@
               this.calcNum = 0 // エラー用計算量を初期化
               this.resetNextSeatsTable(); // 席替え後座席テーブルを初期化する
               this.resetFrontSeatsIndex(); // 最前列インデックス配列を空にする
+              this.resetFrontTwoRowsSeatsIndex(); // 前2列インデックス配列を空にする
+              this.resetBackSeatsIndex(); // 最後列インデックス配列を空にする
+              this.resetBackTwoRowsSeatsIndex(); // 後ろ2列インデックス配列を空にする
               this.makeFrontSeatsIndex(); // 最前列インデックスを作成
+              this.makeFrontTwoRowsSeatsIndex(); // 前2列インデックスを作成
+              this.makeBackSeatsIndex(); // 最後列インデックスを作成
+              this.makeBackTwoRowsSeatsIndex(); // 後ろ2列インデックスを作成
               this.dupSeatsTableIndex = this.seatsTableIndex.slice(0); // 有効な座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupFrontSeatsIndex = this.frontSeatsIndex.slice(0); // 最前列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
+              this.dupFrontTwoRowsSeatsIndex = this.frontTwoRowsSeatsIndex.slice(0); // 前2列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
+              this.dupBackSeatsIndex = this.backSeatsIndex.slice(0); // 最後列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
+              this.dupBackTwoRowsSeatsIndex = this.backTwoRowsSeatsIndex.slice(0); // 後ろ2列の座席のインデックスを複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupStudentsName = this.studentsName.slice(0); // 生徒名を複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupNearStudentsName = this.nearStudentsName.slice(0); // 近づける生徒名を複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupFarStudentsName = this.farStudentsName.slice(0); // 離す生徒名を複製、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupNearFarStudentsName = this.nearStudentsName.concat(this.farStudentsName); // 近づける生徒名と離す生徒名を結合、席替えの際にこの配列から破壊的にデータを取り出していく
               this.dupNearFarStudentsName = Array.from(new Set(this.dupNearFarStudentsName)) // 重複している名前を削除
+
               this.changeFrontSeats(); // 最前列に固定する生徒を席替え
+              this.changeBackSeats(); // 最後列に固定する生徒を席替え
+              this.changeFrontTwoRowsSeats(); // 前2列に固定する生徒を席替え
+              this.changeBackTwoRowsSeats(); // 後ろ2列に固定する生徒を席替え
               //this.changeNearSeats(); // 近づける生徒を席替え
               //this.changeFarSeats(); // 離す生徒を席替え
               this.changeNearFarSeats(); // 近づける/離す生徒を席替え
@@ -483,15 +606,46 @@
               }
             })
           },
+          resetFrontSeatsIndex() { // 最前列インデックス配列を空にする
+            this.frontSeatsIndex.splice(0);
+          },
+          makeFrontTwoRowsSeatsIndex() {
+            this.seatsTableIndex.forEach(indexArray => {
+              if(indexArray[1] <= 1) { // 前2列なら
+                this.frontTwoRowsSeatsIndex.push(indexArray); // 最前列インデックス配列にインデックスをプッシュ
+              }
+            })
+          },
+          resetFrontTwoRowsSeatsIndex() { // 前2列インデックス配列を空にする
+            this.frontTwoRowsSeatsIndex.splice(0);
+          },
+          makeBackSeatsIndex() {
+            this.seatsTableIndex.forEach(indexArray => {
+              if(indexArray[1] === this.seatsSizeY-1) { // 最後列なら
+                this.backSeatsIndex.push(indexArray); // 最後列インデックス配列にインデックスをプッシュ
+              }
+            })
+          },
+          resetBackSeatsIndex() { // 最後列インデックス配列を空にする
+            this.backSeatsIndex.splice(0);
+          },
+          makeBackTwoRowsSeatsIndex() {
+            this.seatsTableIndex.forEach(indexArray => {
+              if(indexArray[1] >= this.seatsSizeY-2) { // 後ろ2列なら
+                this.backTwoRowsSeatsIndex.push(indexArray); // 後ろ2列インデックス配列にインデックスをプッシュ
+              }
+            })
+          },
+          resetBackTwoRowsSeatsIndex() { // 後ろ2列インデックス配列を空にする
+            this.backTwoRowsSeatsIndex.splice(0);
+          },
           changeFrontSeats() { // 最前列に固定する生徒を席替え
             this.shuffle(this.dupFrontSeatsIndex);
             this.frontConditions.forEach(frontStudentName => {
               let topIndex = this.dupFrontSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
-              /* ----近づける/離す処理---- */
+              /* ----近づける/離す/性別チェック---- */
               while( !this.checkNear(frontStudentName, topIndex) || !this.checkFar(frontStudentName, topIndex) || ( this.isFixGender && !this.checkGender(frontStudentName, topIndex)) ){ // どちらかの条件を満たさない間、繰り返す
                 if(this.calcNum > this.seatsNum){
-                  // window.alert('条件を満たす席替えを実現できませんでした。\n何回か試してもエラーが出るようでしたら、条件を変更してください。');
-                  // throw '計算量が100を超えました'
                   this.restartFlag = true;
                   break;
                 }
@@ -502,27 +656,147 @@
               /* ----ここまで---- */
               this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, frontStudentName); // 取り出したインデックスの位置に生徒名を保存
 
-              let deleteIndex = this.dupSeatsTableIndex.indexOf(topIndex); // changeFrontSeats()で配置した生徒は、shuffleSeats()で配置する必要がないため
+              let deleteIndex = this.dupSeatsTableIndex.indexOf(topIndex); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
               this.dupSeatsTableIndex.splice(deleteIndex, 1); // dupSeatsTableIndexから削除する
 
-              let deleteStudentNameIndex = this.dupStudentsName.indexOf(frontStudentName); // changeFrontSeats()で配置した生徒は、shuffleSeats()で配置する必要がないため
+              let deleteStudentNameIndex = this.dupStudentsName.indexOf(frontStudentName); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
               this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
 
-              let deleteNearStudentNameIndex = this.dupNearStudentsName.indexOf(frontStudentName); // changeFrontSeats()で配置した生徒は、changeNearSeats()で配置する必要がないため
+              let deleteNearStudentNameIndex = this.dupNearStudentsName.indexOf(frontStudentName); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
               if(deleteNearStudentNameIndex != -1){ // dupNearStudentsNameにあれば削除する
                 this.dupNearStudentsName.splice(deleteNearStudentNameIndex, 1); // dupNearStudentsNameから削除する
               }
 
-              let deleteFarStudentNameIndex = this.dupFarStudentsName.indexOf(frontStudentName); // changeFrontSeats()で配置した生徒は、changeFarSeats()で配置する必要がないため
+              let deleteFarStudentNameIndex = this.dupFarStudentsName.indexOf(frontStudentName); // ここで配置した生徒は、changeFarSeats()で配置する必要がないため
               if(deleteFarStudentNameIndex != -1){ // dupFarStudentsNameにあれば削除する
                 this.dupFarStudentsName.splice(deleteFarStudentNameIndex, 1); // dupFarStudentsNameから削除する
               }
 
-              let deleteNearFarStudentNameIndex = this.dupNearFarStudentsName.indexOf(frontStudentName); // changeNearFrontSeats()で配置した生徒は、changeFarSeats()で配置する必要がないため
+              let deleteNearFarStudentNameIndex = this.dupNearFarStudentsName.indexOf(frontStudentName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため
               if(deleteNearFarStudentNameIndex != -1){ // dupNearFarStudentsNameにあれば削除する
                 this.dupNearFarStudentsName.splice(deleteNearFarStudentNameIndex, 1); // dupNearFarStudentsNameから削除する
               }
               // console.log(`${frontStudentName}を配置した`)
+            })
+          },
+          changeFrontTwoRowsSeats() { // 前2列に固定する生徒を席替え
+            this.shuffle(this.dupFrontTwoRowsSeatsIndex);
+            this.frontTwoRowsConditions.forEach(frontTwoRowsStudentName => {
+              let topIndex = this.dupFrontTwoRowsSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
+              /* ----近づける/離す/性別チェック---- */
+              while( !this.checkNear(frontTwoRowsStudentName, topIndex) || !this.checkFar(frontTwoRowsStudentName, topIndex) || ( this.isFixGender && !this.checkGender(frontTwoRowsStudentName, topIndex)) ){ // どちらかの条件を満たさない間、繰り返す
+                if(this.calcNum > this.seatsNum){
+                  this.restartFlag = true;
+                  break;
+                }
+                this.dupFrontTwoRowsSeatsIndex.push(topIndex); // 取り出したインデックスを配列の最後にプッシュして
+                topIndex = this.dupFrontTwoRowsSeatsIndex.shift(); // 配列先頭のインデックスを再度取り出す
+                this.calcNum += 1;
+              }
+              /* ----ここまで---- */
+              this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, frontTwoRowsStudentName); // 取り出したインデックスの位置に生徒名を保存
+
+              let deleteIndex = this.dupSeatsTableIndex.indexOf(topIndex); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
+              this.dupSeatsTableIndex.splice(deleteIndex, 1); // dupSeatsTableIndexから削除する
+
+              let deleteStudentNameIndex = this.dupStudentsName.indexOf(frontTwoRowsStudentName); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
+              this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
+
+              let deleteNearStudentNameIndex = this.dupNearStudentsName.indexOf(frontTwoRowsStudentName); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
+              if(deleteNearStudentNameIndex != -1){ // dupNearStudentsNameにあれば削除する
+                this.dupNearStudentsName.splice(deleteNearStudentNameIndex, 1); // dupNearStudentsNameから削除する
+              }
+
+              let deleteFarStudentNameIndex = this.dupFarStudentsName.indexOf(frontTwoRowsStudentName); // ここで配置した生徒は、changeFarSeats()で配置する必要がないため
+              if(deleteFarStudentNameIndex != -1){ // dupFarStudentsNameにあれば削除する
+                this.dupFarStudentsName.splice(deleteFarStudentNameIndex, 1); // dupFarStudentsNameから削除する
+              }
+
+              let deleteNearFarStudentNameIndex = this.dupNearFarStudentsName.indexOf(frontTwoRowsStudentName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため
+              if(deleteNearFarStudentNameIndex != -1){ // dupNearFarStudentsNameにあれば削除する
+                this.dupNearFarStudentsName.splice(deleteNearFarStudentNameIndex, 1); // dupNearFarStudentsNameから削除する
+              }
+              // console.log(`${frontStudentName}を配置した`)
+            })
+          },
+          changeBackSeats() { // 最後列に固定する生徒を席替え
+            this.shuffle(this.dupBackSeatsIndex);
+            this.backConditions.forEach(backStudentName => {
+              let topIndex = this.dupBackSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
+              /* ----近づける/離す/性別チェック---- */
+              while( !this.checkNear(backStudentName, topIndex) || !this.checkFar(backStudentName, topIndex) || ( this.isFixGender && !this.checkGender(backStudentName, topIndex)) ){ // どちらかの条件を満たさない間、繰り返す
+                if(this.calcNum > this.seatsNum){
+                  this.restartFlag = true;
+                  break;
+                }
+                this.dupBackSeatsIndex.push(topIndex); // 取り出したインデックスを配列の最後にプッシュして
+                topIndex = this.dupBackSeatsIndex.shift(); // 配列先頭のインデックスを再度取り出す
+                this.calcNum += 1;
+              }
+              /* ----ここまで---- */
+              this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, backStudentName); // 取り出したインデックスの位置に生徒名を保存
+
+              let deleteIndex = this.dupSeatsTableIndex.indexOf(topIndex); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
+              this.dupSeatsTableIndex.splice(deleteIndex, 1); // dupSeatsTableIndexから削除する
+
+              let deleteStudentNameIndex = this.dupStudentsName.indexOf(backStudentName); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
+              this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
+
+              let deleteNearStudentNameIndex = this.dupNearStudentsName.indexOf(backStudentName); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
+              if(deleteNearStudentNameIndex != -1){ // dupNearStudentsNameにあれば削除する
+                this.dupNearStudentsName.splice(deleteNearStudentNameIndex, 1); // dupNearStudentsNameから削除する
+              }
+
+              let deleteFarStudentNameIndex = this.dupFarStudentsName.indexOf(backStudentName); // ここで配置した生徒は、changeFarSeats()で配置する必要がないため
+              if(deleteFarStudentNameIndex != -1){ // dupFarStudentsNameにあれば削除する
+                this.dupFarStudentsName.splice(deleteFarStudentNameIndex, 1); // dupFarStudentsNameから削除する
+              }
+
+              let deleteNearFarStudentNameIndex = this.dupNearFarStudentsName.indexOf(backStudentName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため
+              if(deleteNearFarStudentNameIndex != -1){ // dupNearFarStudentsNameにあれば削除する
+                this.dupNearFarStudentsName.splice(deleteNearFarStudentNameIndex, 1); // dupNearFarStudentsNameから削除する
+              }
+              // console.log(`${backStudentName}を配置した`)
+            })
+          },
+          changeBackTwoRowsSeats() { // 後ろ2列に固定する生徒を席替え
+            this.shuffle(this.dupBackTwoRowsSeatsIndex);
+            this.backTwoRowsConditions.forEach(backTwoRowsStudentName => {
+              let topIndex = this.dupBackTwoRowsSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
+              /* ----近づける/離す/性別チェック---- */
+              while( !this.checkNear(backTwoRowsStudentName, topIndex) || !this.checkFar(backTwoRowsStudentName, topIndex) || ( this.isFixGender && !this.checkGender(backTwoRowsStudentName, topIndex)) ){ // どちらかの条件を満たさない間、繰り返す
+                if(this.calcNum > this.seatsNum){
+                  this.restartFlag = true;
+                  break;
+                }
+                this.dupBackTwoRowsSeatsIndex.push(topIndex); // 取り出したインデックスを配列の最後にプッシュして
+                topIndex = this.dupBackTwoRowsSeatsIndex.shift(); // 配列先頭のインデックスを再度取り出す
+                this.calcNum += 1;
+              }
+              /* ----ここまで---- */
+              this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, backTwoRowsStudentName); // 取り出したインデックスの位置に生徒名を保存
+
+              let deleteIndex = this.dupSeatsTableIndex.indexOf(topIndex); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
+              this.dupSeatsTableIndex.splice(deleteIndex, 1); // dupSeatsTableIndexから削除する
+
+              let deleteStudentNameIndex = this.dupStudentsName.indexOf(backTwoRowsStudentName); // ここで配置した生徒は、shuffleSeats()で配置する必要がないため
+              this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
+
+              let deleteNearStudentNameIndex = this.dupNearStudentsName.indexOf(backTwoRowsStudentName); // ここで配置した生徒は、changeNearSeats()で配置する必要がないため
+              if(deleteNearStudentNameIndex != -1){ // dupNearStudentsNameにあれば削除する
+                this.dupNearStudentsName.splice(deleteNearStudentNameIndex, 1); // dupNearStudentsNameから削除する
+              }
+
+              let deleteFarStudentNameIndex = this.dupFarStudentsName.indexOf(backTwoRowsStudentName); // ここで配置した生徒は、changeFarSeats()で配置する必要がないため
+              if(deleteFarStudentNameIndex != -1){ // dupFarStudentsNameにあれば削除する
+                this.dupFarStudentsName.splice(deleteFarStudentNameIndex, 1); // dupFarStudentsNameから削除する
+              }
+
+              let deleteNearFarStudentNameIndex = this.dupNearFarStudentsName.indexOf(backTwoRowsStudentName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため
+              if(deleteNearFarStudentNameIndex != -1){ // dupNearFarStudentsNameにあれば削除する
+                this.dupNearFarStudentsName.splice(deleteNearFarStudentNameIndex, 1); // dupNearFarStudentsNameから削除する
+              }
+              // console.log(`${backStudentName}を配置した`)
             })
           },
           /*
@@ -609,9 +883,6 @@
               this.dupStudentsName.splice(deleteStudentNameIndex, 1); // dupStudentsNameから削除する
               // console.log(`${dupNearFarStudentName}を配置した`)
             })
-          },
-          resetFrontSeatsIndex() { // 最前列インデックス配列を空にする
-            this.frontSeatsIndex.splice(0);
           },
           min_distance(p1, p2) { // 2点の距離のminを返す。p1, p2は座標、たとえばp1=[1,2]
             let x_abs = Math.abs( p1[0] - p2[0] );


### PR DESCRIPTION
- 固定で配置したインデックスは最前列配置などで使えないので、delete()を実行して修正
- 距離の選択肢に実現不可能な値が含まれていたので、watchでX/Yを監視して選ばれた値によって動的に選択肢を変更するように修正
- 近づける/離すフォームの表記を変更
- 距離の表記の変更にともなって、デフォルトの選択肢も実現可能なものだけに修正
-  距離の表記の変更にともなって、checkNear()とcheckFar()内の処理における距離のズレを修正
- ループ上限回数を100回から500回に変更