### PR TITLE
[Add] カードの位置を中央に設定

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,9 @@
       .margin-bottom {
         padding-bottom: 10px;
       }
+      .card-bottom {
+        padding-bottom: 30px;
+      }
       .padding-35 {
         padding:35px 0;
       }
@@ -129,156 +132,152 @@
             </v-col>
           </v-row>
 
-          <v-row>
-            <v-col cols="6">
-              <!-- サイドバー -->
-              <template>
-                <v-navigation-drawer absolute width="50%" color="#e4e4e4" :mini-variant="!drawer" right>
-                  <v-list nav dense>
-                    <v-list-item-group>
-                      <v-list-item class="right" @click.stop="drawer = !drawer">
-                        <v-app-bar-nav-icon></v-app-bar-nav-icon>
-                      </v-list-item>
-                      <template v-if="drawer">
-                        <h1 class="padding-35">条件</h1>
-                        <!-- 座席数のセレクトボックス -->
-                        <v-select :items="seatsOptionsX" label="全体の横の座席数" outlined　v-model.number="seatsSizeX" style="width:125px" class="inline-block"></v-select>
-                        <v-select :items="seatsOptionsY" label="全体の縦の座席数" outlined　v-model.number="seatsSizeY" style="width:125px" class="inline-block"></v-select>
-                        <v-select :items="groupSizeOptionsX" label="班の横の座席数" outlined　v-model.number="groupSizeX" style="width:110px" class="inline-block"></v-select>
-                        <v-select :items="groupSizeOptionsY" label="班の縦の座席数" outlined　v-model.number="groupSizeY" style="width:110px" class="inline-block"></v-select>
+          <!-- サイドバー -->
+          <template>
+            <v-navigation-drawer absolute width="50%" color="#e4e4e4" :mini-variant="!drawer" right>
+              <v-list nav dense>
+                <v-list-item-group>
+                  <v-list-item class="right" @click.stop="drawer = !drawer">
+                    <v-app-bar-nav-icon></v-app-bar-nav-icon>
+                  </v-list-item>
+                  <template v-if="drawer">
+                    <h1 class="padding-35">条件</h1>
+                    <!-- 座席数のセレクトボックス -->
+                    <v-select :items="seatsOptionsX" label="全体の横の座席数" outlined　v-model.number="seatsSizeX" style="width:125px" class="inline-block"></v-select>
+                    <v-select :items="seatsOptionsY" label="全体の縦の座席数" outlined　v-model.number="seatsSizeY" style="width:125px" class="inline-block"></v-select>
+                    <v-select :items="groupSizeOptionsX" label="班の横の座席数" outlined　v-model.number="groupSizeX" style="width:110px" class="inline-block"></v-select>
+                    <v-select :items="groupSizeOptionsY" label="班の縦の座席数" outlined　v-model.number="groupSizeY" style="width:110px" class="inline-block"></v-select>
 
-                        <!-- 前後で指定するエクスパンションパネル -->
-                        <v-expansion-panels accordion class="expansion-panels">
-                          <v-expansion-panel>
-                            <v-expansion-panel-header>前後で指定する</v-expansion-panel-header>
-                            <v-expansion-panel-content>
-                              <v-expansion-panels accordion multiple>
-                                <!-- 最前列のエクスパンションパネル -->
-                                <v-expansion-panel>
-                                  <v-expansion-panel-header>最前列</v-expansion-panel-header>
-                                  <v-expansion-panel-content>
-                                    <span v-for="(frontCondition, frontIndex) in frontConditions">
-                                      <v-select :items="rowConditionsStudentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
-                                      v-model="frontConditions[frontIndex]" @change.once="createNewFrontConditions"></v-select>
-                                    </span>
-                                  </v-expansion-panel-content>
-                                </v-expansion-panel>
-                                <!-- 前2列のエクスパンションパネル -->
-                                <v-expansion-panel>
-                                  <v-expansion-panel-header>前2列</v-expansion-panel-header>
-                                  <v-expansion-panel-content>
-                                    <span v-for="(frontTwoRowsCondition, frontTwoRowsIndex) in frontTwoRowsConditions">
-                                      <v-select :items="rowConditionsStudentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
-                                      v-model="frontTwoRowsConditions[frontTwoRowsIndex]" @change.once="createNewFrontTwoRowsConditions"></v-select>
-                                    </span>
-                                  </v-expansion-panel-content>
-                                </v-expansion-panel>
-                                <!-- 後ろ2列のエクスパンションパネル -->
-                                <v-expansion-panel>
-                                  <v-expansion-panel-header>後ろ2列</v-expansion-panel-header>
-                                  <v-expansion-panel-content>
-                                    <span v-for="(backTwoRowsCondition, backTwoRowsIndex) in backTwoRowsConditions">
-                                      <v-select :items="rowConditionsStudentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
-                                      v-model="backTwoRowsConditions[backTwoRowsIndex]" @change.once="createNewBackTwoRowsConditions"></v-select>
-                                    </span>
-                                  </v-expansion-panel-content>
-                                </v-expansion-panel>
-                                <!-- 最後列のエクスパンションパネル -->
-                                <v-expansion-panel>
-                                  <v-expansion-panel-header>最後列</v-expansion-panel-header>
-                                  <v-expansion-panel-content>
-                                    <span v-for="(backCondition, backIndex) in backConditions">
-                                      <v-select :items="rowConditionsStudentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
-                                      v-model="backConditions[backIndex]" @change.once="createNewBackConditions"></v-select>
-                                    </span>
-                                  </v-expansion-panel-content>
-                                </v-expansion-panel>
-                              </v-expansion-panels>
-                            </v-expansion-panel-content>
-                          </v-expansion-panel>
-                        </v-expansion-panels>
+                    <!-- 前後で指定するエクスパンションパネル -->
+                    <v-expansion-panels accordion class="expansion-panels">
+                      <v-expansion-panel>
+                        <v-expansion-panel-header>前後で指定する</v-expansion-panel-header>
+                        <v-expansion-panel-content>
+                          <v-expansion-panels accordion multiple>
+                            <!-- 最前列のエクスパンションパネル -->
+                            <v-expansion-panel>
+                              <v-expansion-panel-header>最前列</v-expansion-panel-header>
+                              <v-expansion-panel-content>
+                                <span v-for="(frontCondition, frontIndex) in frontConditions">
+                                  <v-select :items="rowConditionsStudentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
+                                  v-model="frontConditions[frontIndex]" @change.once="createNewFrontConditions"></v-select>
+                                </span>
+                              </v-expansion-panel-content>
+                            </v-expansion-panel>
+                            <!-- 前2列のエクスパンションパネル -->
+                            <v-expansion-panel>
+                              <v-expansion-panel-header>前2列</v-expansion-panel-header>
+                              <v-expansion-panel-content>
+                                <span v-for="(frontTwoRowsCondition, frontTwoRowsIndex) in frontTwoRowsConditions">
+                                  <v-select :items="rowConditionsStudentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
+                                  v-model="frontTwoRowsConditions[frontTwoRowsIndex]" @change.once="createNewFrontTwoRowsConditions"></v-select>
+                                </span>
+                              </v-expansion-panel-content>
+                            </v-expansion-panel>
+                            <!-- 後ろ2列のエクスパンションパネル -->
+                            <v-expansion-panel>
+                              <v-expansion-panel-header>後ろ2列</v-expansion-panel-header>
+                              <v-expansion-panel-content>
+                                <span v-for="(backTwoRowsCondition, backTwoRowsIndex) in backTwoRowsConditions">
+                                  <v-select :items="rowConditionsStudentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
+                                  v-model="backTwoRowsConditions[backTwoRowsIndex]" @change.once="createNewBackTwoRowsConditions"></v-select>
+                                </span>
+                              </v-expansion-panel-content>
+                            </v-expansion-panel>
+                            <!-- 最後列のエクスパンションパネル -->
+                            <v-expansion-panel>
+                              <v-expansion-panel-header>最後列</v-expansion-panel-header>
+                              <v-expansion-panel-content>
+                                <span v-for="(backCondition, backIndex) in backConditions">
+                                  <v-select :items="rowConditionsStudentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
+                                  v-model="backConditions[backIndex]" @change.once="createNewBackConditions"></v-select>
+                                </span>
+                              </v-expansion-panel-content>
+                            </v-expansion-panel>
+                          </v-expansion-panels>
+                        </v-expansion-panel-content>
+                      </v-expansion-panel>
+                    </v-expansion-panels>
 
-                        <!-- 特定の座席に固定するエクスパンションパネル -->
-                        <v-expansion-panels accordion class="expansion-panels">
-                          <v-expansion-panel>
-                            <v-expansion-panel-header>特定の座席に固定する</v-expansion-panel-header>
-                            <v-expansion-panel-content>
-                              <div v-for="(fixCondition, fixIndex) in fixConditions">
-                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
-                                v-model="fixConditions[fixIndex][0]"></v-select>
-                                を、前から
-                                <v-select :items="limitedSeatsOptionsY" outlined style="width:70px; display: inline-block"
-                                v-model="fixConditions[fixIndex][1]"></v-select>
-                                列目、左から
-                                <v-select :items="limitedSeatsOptionsX" outlined style="width:70px; display: inline-block"
-                                v-model="fixConditions[fixIndex][2]" @change.once="createNewFixConditions"></v-select>
-                                列目に固定する
-                              </div>
-                            </v-expansion-panel-content>
-                          </v-expansion-panel>
-                        </v-expansion-panels>
+                    <!-- 特定の座席に固定するエクスパンションパネル -->
+                    <v-expansion-panels accordion class="expansion-panels">
+                      <v-expansion-panel>
+                        <v-expansion-panel-header>特定の座席に固定する</v-expansion-panel-header>
+                        <v-expansion-panel-content>
+                          <div v-for="(fixCondition, fixIndex) in fixConditions">
+                            <v-select :items="studentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
+                            v-model="fixConditions[fixIndex][0]"></v-select>
+                            を、前から
+                            <v-select :items="limitedSeatsOptionsY" outlined style="width:70px; display: inline-block"
+                            v-model="fixConditions[fixIndex][1]"></v-select>
+                            列目、左から
+                            <v-select :items="limitedSeatsOptionsX" outlined style="width:70px; display: inline-block"
+                            v-model="fixConditions[fixIndex][2]" @change.once="createNewFixConditions"></v-select>
+                            列目に固定する
+                          </div>
+                        </v-expansion-panel-content>
+                      </v-expansion-panel>
+                    </v-expansion-panels>
 
-                        <!-- 近づける生徒のエクスパンションパネル -->
-                        <v-expansion-panels accordion class="expansion-panels">
-                          <v-expansion-panel>
-                            <v-expansion-panel-header>生徒同士を近づける</v-expansion-panel-header>
-                            <v-expansion-panel-content>
-                              <div v-for="(nearCondition, nearIndex) in nearConditions">
-                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
-                                v-model="nearConditions[nearIndex][0]"></v-select>
-                                と
-                                <v-select :items="studentsName" placeholder="Bさん" outlined style="width:190px; display: inline-block"
-                                v-model="nearConditions[nearIndex][1]"></v-select>
-                                の間を
-                                <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                                v-model="nearConditions[nearIndex][2]" @change.once="createNewNearConditions"></v-select>
-                                席以下にする
-                              </div>
-                            </v-expansion-panel-content>
-                          </v-expansion-panel>
-                        </v-expansion-panels>
+                    <!-- 近づける生徒のエクスパンションパネル -->
+                    <v-expansion-panels accordion class="expansion-panels">
+                      <v-expansion-panel>
+                        <v-expansion-panel-header>生徒同士を近づける</v-expansion-panel-header>
+                        <v-expansion-panel-content>
+                          <div v-for="(nearCondition, nearIndex) in nearConditions">
+                            <v-select :items="studentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
+                            v-model="nearConditions[nearIndex][0]"></v-select>
+                            と
+                            <v-select :items="studentsName" placeholder="Bさん" outlined style="width:190px; display: inline-block"
+                            v-model="nearConditions[nearIndex][1]"></v-select>
+                            の間を
+                            <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
+                            v-model="nearConditions[nearIndex][2]" @change.once="createNewNearConditions"></v-select>
+                            席以下にする
+                          </div>
+                        </v-expansion-panel-content>
+                      </v-expansion-panel>
+                    </v-expansion-panels>
 
-                        <!-- 離す生徒のエクスパンションパネル -->
-                        <v-expansion-panels accordion class="expansion-panels">
-                          <v-expansion-panel>
-                            <v-expansion-panel-header>生徒同士を離す</v-expansion-panel-header>
-                            <v-expansion-panel-content>
-                              <div v-for="(farCondition, farIndex) in farConditions">
-                                <v-select :items="studentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
-                                v-model="farConditions[farIndex][0]"></v-select>
-                                と
-                                <v-select :items="studentsName" placeholder="Bさん" outlined style="width:190px; display: inline-block"
-                                v-model="farConditions[farIndex][1]"></v-select>
-                                の間を
-                                <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
-                                v-model="farConditions[farIndex][2]" @change.once="createNewFarConditions"></v-select>
-                                席以上空ける
-                              </div>
-                            </v-expansion-panel-content>
-                          </v-expansion-panel>
-                        </v-expansion-panels>
+                    <!-- 離す生徒のエクスパンションパネル -->
+                    <v-expansion-panels accordion class="expansion-panels">
+                      <v-expansion-panel>
+                        <v-expansion-panel-header>生徒同士を離す</v-expansion-panel-header>
+                        <v-expansion-panel-content>
+                          <div v-for="(farCondition, farIndex) in farConditions">
+                            <v-select :items="studentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
+                            v-model="farConditions[farIndex][0]"></v-select>
+                            と
+                            <v-select :items="studentsName" placeholder="Bさん" outlined style="width:190px; display: inline-block"
+                            v-model="farConditions[farIndex][1]"></v-select>
+                            の間を
+                            <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
+                            v-model="farConditions[farIndex][2]" @change.once="createNewFarConditions"></v-select>
+                            席以上空ける
+                          </div>
+                        </v-expansion-panel-content>
+                      </v-expansion-panel>
+                    </v-expansion-panels>
 
-                        <!-- チェックボックス -->
-                        <v-checkbox label="現在の座席と異なる座席にする" v-model="isAllDifferent" hide-details></v-checkbox>
-                        <v-checkbox label="男女の座席を固定する" v-model="isFixGender" hide-details></v-checkbox>
+                    <!-- チェックボックス -->
+                    <v-checkbox label="現在の座席と異なる座席にする" v-model="isAllDifferent" hide-details></v-checkbox>
+                    <v-checkbox label="男女の座席を固定する" v-model="isFixGender" hide-details></v-checkbox>
 
-                        <!-- 席替えボタン -->
-                        <v-btn elevation="2" outlined @click="beforeChangeSeats(); delayChangeSeats(); drawer = false" class="change-seats-button">席替え！</v-btn>
-                      </template>
-                    </v-list-item-group>
-                  </v-list>
-                </v-navigation-drawer>
-                <!-- サイドバーここまで -->
-              </template>
-            </v-col>
-          </v-row>
+                    <!-- 席替えボタン -->
+                    <v-btn elevation="2" outlined @click="beforeChangeSeats(); delayChangeSeats(); drawer = false" class="change-seats-button">席替え！</v-btn>
+                  </template>
+                </v-list-item-group>
+              </v-list>
+            </v-navigation-drawer>
+            <!-- サイドバーここまで -->
+          </template>
 
           <v-row>
             <!-- 座席テーブル -->
             <v-col cols="6">
               <v-card outlined color="#0d6399" class="box-shadow rounded-xl">
-                <v-card-title class="justify-center white--text text-h4">現在の座席</v-card-title>
-                <v-card-subtitle class="justify-center text-center white--text">現在の座席に名前を入力してください<br>クリックで性別を変更できます</v-card-subtitle>
+                <v-card-title class="justify-center white--text text-h4">今の座席</v-card-title>
+                <!--v-card-subtitle class="justify-center text-center white--text">現在の座席に名前を入力してください<br>クリックで性別を変更できます</v-card-subtitle-->
                 <div>
                   <li v-for="( seats, indexRow ) in seatsTable">
                     <span v-for="( seat, indexCol ) in seats" class="minus-margin-right">
@@ -295,6 +294,7 @@
                   <div :class="{'margin-bottom': (indexRow+1)%groupSizeY==0}"></div>
                   </li>
                 </div>
+                <div class="card-bottom"></div>
               </v-card>
               <v-btn elevation="2" outlined @click="beforeChangeSeats(); delayChangeSeats(); drawer = false">席替え！</v-btn>
             </v-col>
@@ -302,8 +302,8 @@
             <!-- 席替え後の座席テーブル -->
             <v-col cols="6">
               <v-card outlined color="#0d6399" class="box-shadow rounded-xl">
-                <v-card-title class="justify-center white--text text-h4">席替え後の座席</v-card-title>
-                <v-card-subtitle class="justify-center text-center"><br><br></v-card-subtitle>
+                <v-card-title class="justify-center white--text text-h4">席替え後</v-card-title>
+                <!--v-card-subtitle class="justify-center text-center"><br><br></v-card-subtitle-->
                 <template v-if="isRenderNextSeatsTable">
                   <div class="center">
                     <transition-group name="transition-item" type="transition">
@@ -324,6 +324,7 @@
                     </transition-group>
                   </div>
                 </template>
+                <div class="card-bottom"></div>
               </v-card>
             </v-col>
 

--- a/index.html
+++ b/index.html
@@ -60,12 +60,8 @@
       .margin-bottom {
         padding-bottom: 10px;
       }
-      .margin-bottom-35 {
-        margin:35px 0;
-      }
-      .margin-top-35 {
-        margin-top: 35px;
-        margin-bottom: -50px;
+      .padding-35 {
+        padding:35px 0;
       }
       .minus-margin-bottom {
         vertical-align: bottom;
@@ -144,7 +140,7 @@
                         <v-app-bar-nav-icon @click.stop="drawer = !drawer"></v-app-bar-nav-icon>
                       </v-list-item>
                       <template v-if="drawer">
-                        <h1 class="margin-bottom-35">条件</h1>
+                        <h1 class="padding-35">条件</h1>
                         <!-- 座席数のセレクトボックス -->
                         <v-select :items="seatsOptionsX" label="全体の横の座席数" outlined　v-model.number="seatsSizeX" style="width:125px" class="inline-block"></v-select>
                         <v-select :items="seatsOptionsY" label="全体の縦の座席数" outlined　v-model.number="seatsSizeY" style="width:125px" class="inline-block"></v-select>

--- a/index.html
+++ b/index.html
@@ -205,13 +205,13 @@
                         <v-expansion-panel-header>特定の座席に固定する</v-expansion-panel-header>
                         <v-expansion-panel-content>
                           <div v-for="(fixCondition, fixIndex) in fixConditions">
-                            <v-select :items="studentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
+                            <v-select :items="studentsName" placeholder="Aさん" outlined style="width:185px; display: inline-block"
                             v-model="fixConditions[fixIndex][0]"></v-select>
                             を、前から
-                            <v-select :items="limitedSeatsOptionsY" outlined style="width:70px; display: inline-block"
+                            <v-select :items="limitedSeatsOptionsY" outlined style="width:65px; display: inline-block"
                             v-model="fixConditions[fixIndex][1]"></v-select>
                             列目、左から
-                            <v-select :items="limitedSeatsOptionsX" outlined style="width:70px; display: inline-block"
+                            <v-select :items="limitedSeatsOptionsX" outlined style="width:65px; display: inline-block"
                             v-model="fixConditions[fixIndex][2]" @change.once="createNewFixConditions"></v-select>
                             列目に固定する
                           </div>
@@ -225,13 +225,13 @@
                         <v-expansion-panel-header>生徒同士を近づける</v-expansion-panel-header>
                         <v-expansion-panel-content>
                           <div v-for="(nearCondition, nearIndex) in nearConditions">
-                            <v-select :items="studentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
+                            <v-select :items="studentsName" placeholder="Aさん" outlined style="width:185px; display: inline-block"
                             v-model="nearConditions[nearIndex][0]"></v-select>
                             と
-                            <v-select :items="studentsName" placeholder="Bさん" outlined style="width:190px; display: inline-block"
+                            <v-select :items="studentsName" placeholder="Bさん" outlined style="width:185px; display: inline-block"
                             v-model="nearConditions[nearIndex][1]"></v-select>
                             の間を
-                            <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
+                            <v-select :items="distanceOptions" outlined style="width:65px; display: inline-block"
                             v-model="nearConditions[nearIndex][2]" @change.once="createNewNearConditions"></v-select>
                             席以下にする
                           </div>
@@ -245,13 +245,13 @@
                         <v-expansion-panel-header>生徒同士を離す</v-expansion-panel-header>
                         <v-expansion-panel-content>
                           <div v-for="(farCondition, farIndex) in farConditions">
-                            <v-select :items="studentsName" placeholder="Aさん" outlined style="width:190px; display: inline-block"
+                            <v-select :items="studentsName" placeholder="Aさん" outlined style="width:185px; display: inline-block"
                             v-model="farConditions[farIndex][0]"></v-select>
                             と
-                            <v-select :items="studentsName" placeholder="Bさん" outlined style="width:190px; display: inline-block"
+                            <v-select :items="studentsName" placeholder="Bさん" outlined style="width:185px; display: inline-block"
                             v-model="farConditions[farIndex][1]"></v-select>
                             の間を
-                            <v-select :items="distanceOptions" outlined style="width:70px; display: inline-block"
+                            <v-select :items="distanceOptions" outlined style="width:65px; display: inline-block"
                             v-model="farConditions[farIndex][2]" @change.once="createNewFarConditions"></v-select>
                             席以上空ける
                           </div>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
         padding-bottom: 10px;
       }
       .card-bottom {
-        padding-bottom: 30px;
+        padding-bottom: 35px;
       }
       .padding-35 {
         padding:35px 0;
@@ -275,57 +275,61 @@
           <v-row>
             <!-- 座席テーブル -->
             <v-col cols="6">
-              <v-card outlined color="#0d6399" class="box-shadow rounded-xl">
-                <v-card-title class="justify-center white--text text-h4">今の座席</v-card-title>
-                <!--v-card-subtitle class="justify-center text-center white--text">現在の座席に名前を入力してください<br>クリックで性別を変更できます</v-card-subtitle-->
-                <div>
-                  <li v-for="( seats, indexRow ) in seatsTable">
-                    <span v-for="( seat, indexCol ) in seats" class="minus-margin-right">
-                      <textarea
-                      :class="['seat', getColorByName(seatsTable[indexRow][indexCol]), ]"
-                      @input="writeStudentName( indexCol, indexRow, $event.target.value ); countSeats();"
-                      :key="indexRow.toString() + indexCol.toString()"
-                      style="text-align: center;  resize: none; word-break: keep-all"
-                      :value="seatsTable[indexRow][indexCol]"
-                      @click="toggleGender(indexCol,indexRow)">
-                    </textarea>
-                    <span :class="{'margin-right': (indexCol+1)%groupSizeX==0}"></span>
-                  </span>
-                  <div :class="{'margin-bottom': (indexRow+1)%groupSizeY==0}"></div>
-                  </li>
-                </div>
-                <div class="card-bottom"></div>
-              </v-card>
+              <v-layout justify-center>
+                <v-card outlined color="#0d6399" class="box-shadow rounded-xl" width="620px">
+                  <v-card-title class="justify-center white--text text-h4">今の座席</v-card-title>
+                  <!--v-card-subtitle class="justify-center text-center white--text">現在の座席に名前を入力してください<br>クリックで性別を変更できます</v-card-subtitle-->
+                  <div>
+                    <li v-for="( seats, indexRow ) in seatsTable">
+                      <span v-for="( seat, indexCol ) in seats" class="minus-margin-right">
+                        <textarea
+                        :class="['seat', getColorByName(seatsTable[indexRow][indexCol]), ]"
+                        @input="writeStudentName( indexCol, indexRow, $event.target.value ); countSeats();"
+                        :key="indexRow.toString() + indexCol.toString()"
+                        style="text-align: center;  resize: none; word-break: keep-all"
+                        :value="seatsTable[indexRow][indexCol]"
+                        @click="toggleGender(indexCol,indexRow)">
+                      </textarea>
+                      <span :class="{'margin-right': (indexCol+1)%groupSizeX==0}"></span>
+                    </span>
+                    <div :class="{'margin-bottom': (indexRow+1)%groupSizeY==0}"></div>
+                    </li>
+                  </div>
+                  <div class="card-bottom"></div>
+                </v-card>
+              </v-layout>
               <v-btn elevation="2" outlined @click="beforeChangeSeats(); delayChangeSeats(); drawer = false">席替え！</v-btn>
             </v-col>
 
             <!-- 席替え後の座席テーブル -->
             <v-col cols="6">
-              <v-card outlined color="#0d6399" class="box-shadow rounded-xl">
-                <v-card-title class="justify-center white--text text-h4">席替え後</v-card-title>
-                <!--v-card-subtitle class="justify-center text-center"><br><br></v-card-subtitle-->
-                <template v-if="isRenderNextSeatsTable">
-                  <div class="center">
-                    <transition-group name="transition-item" type="transition">
-                      <template v-for="( nextSeats, nextIndexRow ) in nextSeatsTable" >
-                        <template v-for="( nextSeat, nextIndexCol ) in nextSeats">
-                          <span :id="'nextSeatsRow' + nextIndexRow + nextIndexCol" class="sortable-item transition-item square minus-margin-bottom" :key="uniqueKey(nextSeat, nextIndexRow, nextIndexCol)">
-                            <textarea class="sortable-item"
-                            :class="['seat', getColorByName(nextSeatsTable[nextIndexRow][nextIndexCol])]"
-                            style="text-align: center;  resize: none; word-break: keep-all"
-                            :value="nextSeatsTable[nextIndexRow][nextIndexCol]"
-                            @input="testMethod2(nextIndexCol, nextIndexRow, $event.target.value )">
-                            </textarea>
-                          </span>
-                          <span :class="{'margin-right': (nextIndexCol+1)%groupSizeX==0}" :key="'nextSeatsSpan' + (nextIndexRow*seatsSizeX+nextIndexCol)"></span>
+              <v-layout justify-center>
+                <v-card outlined color="#0d6399" class="box-shadow rounded-xl" width="620px">
+                  <v-card-title class="justify-center white--text text-h4">席替え後</v-card-title>
+                  <!--v-card-subtitle class="justify-center text-center"><br><br></v-card-subtitle-->
+                  <template v-if="isRenderNextSeatsTable">
+                    <div class="center">
+                      <transition-group name="transition-item" type="transition">
+                        <template v-for="( nextSeats, nextIndexRow ) in nextSeatsTable" >
+                          <template v-for="( nextSeat, nextIndexCol ) in nextSeats">
+                            <span :id="'nextSeatsRow' + nextIndexRow + nextIndexCol" class="sortable-item transition-item square minus-margin-bottom" :key="uniqueKey(nextSeat, nextIndexRow, nextIndexCol)">
+                              <textarea class="sortable-item"
+                              :class="['seat', getColorByName(nextSeatsTable[nextIndexRow][nextIndexCol])]"
+                              style="text-align: center;  resize: none; word-break: keep-all"
+                              :value="nextSeatsTable[nextIndexRow][nextIndexCol]"
+                              @input="testMethod2(nextIndexCol, nextIndexRow, $event.target.value )">
+                              </textarea>
+                            </span>
+                            <span :class="{'margin-right': (nextIndexCol+1)%groupSizeX==0}" :key="'nextSeatsSpan' + (nextIndexRow*seatsSizeX+nextIndexCol)"></span>
+                          </template>
+                          <div :class="{'margin-bottom': (nextIndexRow+1)%groupSizeY==0}" :key="'nextSeatsDiv' + (nextIndexRow)"></div>
                         </template>
-                        <div :class="{'margin-bottom': (nextIndexRow+1)%groupSizeY==0}" :key="'nextSeatsDiv' + (nextIndexRow)"></div>
-                      </template>
-                    </transition-group>
-                  </div>
-                </template>
-                <div class="card-bottom"></div>
-              </v-card>
+                      </transition-group>
+                    </div>
+                  </template>
+                  <div class="card-bottom"></div>
+                </v-card>
+            </v-layout>
             </v-col>
 
 

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
           <v-row>
             <!-- タイトル -->
             <v-col cols="6">
-              <h1 class="text-center">席替えメーカー</h1>
+              <h1 class="text-center font" style="color: #FFFFFF; font-size: 50px;">席替えメーカー</h1>
             </v-col>
           </v-row>
 

--- a/index.html
+++ b/index.html
@@ -34,13 +34,13 @@
         background: mediumaquamarine;
       }
       .male-seats {
-        background: #d1e8ff;
+        background: #cce5ff;
       }
       .female-seats {
-        background: #ffe5f2;
+        background: #ffdbff;
       }
       .off-seats {
-        background: #fffafa;
+        background: #ffffff;
       }
       .seat{
         height: 80px;

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
         border-width: 0 1px 0 1px;
       }
       .box-shadow {
-        box-shadow: 0 0 6px 6px rgba(220,220,220,0.5);
+        box-shadow: 0 0 3px 3px rgba(170,170,170,0.5);
       }
       [v-cloak] {
         display: none;
@@ -133,11 +133,11 @@
             <v-col cols="6">
               <!-- サイドバー -->
               <template>
-                <v-navigation-drawer absolute right width="50%" color="#e4e4e4" :mini-variant="!drawer">
+                <v-navigation-drawer absolute width="50%" color="#e4e4e4" :mini-variant="!drawer" right>
                   <v-list nav dense>
                     <v-list-item-group>
-                      <v-list-item class="right">
-                        <v-app-bar-nav-icon @click.stop="drawer = !drawer"></v-app-bar-nav-icon>
+                      <v-list-item class="right" @click.stop="drawer = !drawer">
+                        <v-app-bar-nav-icon></v-app-bar-nav-icon>
                       </v-list-item>
                       <template v-if="drawer">
                         <h1 class="padding-35">条件</h1>


### PR DESCRIPTION
- seatの色を変更
- サイドバー開閉アイコンの位置がずれないように修正
- カードの影を濃いグレーに変更
- タイトルを大きく表示
- カードの最下部にmarginを設定
- 条件が一列に収まるようにフォームの大きさを縮小
- カードの位置を中央に設定