### PR TITLE
班長の星がドラッグ並び替えで相手に付く不具合を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,6 +404,12 @@
       background-color: #EEEEEE;
     }
 
+    /* swapClassはドラッグ単位のラッパーdivに付くため、
+       前面の不透明なinput(座席)にもハイライト色を反映させる */
+    .highlighted input {
+      background-color: #EEEEEE;
+    }
+
     .sortable-item:hover {
       cursor: grab;
     }
@@ -1032,16 +1038,20 @@
                 <template v-for="( nextSeats, nextIndexRow ) in nextSeatsTable">
                   <template v-for="( nextSeat, nextIndexCol ) in nextSeats">
                     <span :id="'nextSeatsRow-' + nextIndexRow + '-' + nextIndexCol"
-                      class="sortable-item transition-item square minus-margin-bottom"
-                      :key="uniqueKey(nextSeat, nextIndexRow, nextIndexCol)" style="position: relative;">
-                      <input type="text" class="sortable-item" readonly
-                        :class="['seat', getColorByName(nextSeatsTable[nextIndexRow][nextIndexCol], 1, 1)]"
-                        style="text-align: center;  resize: none; word-break: keep-all; vertical-align: top; font-size: 22px; font-weight: 600;"
-                        :value="nextSeatsTable[nextIndexRow][nextIndexCol]">
-                      <v-icon
-                        v-if="nextSeatsTable[nextIndexRow][nextIndexCol] && leaderConditions.includes(nextSeatsTable[nextIndexRow][nextIndexCol])"
-                        color="#F9A825"
-                        style="position: absolute; top: 4px; left: 4px; font-size: 24px;">mdi-star</v-icon>
+                      class="transition-item square minus-margin-bottom"
+                      :key="uniqueKey(nextSeat, nextIndexRow, nextIndexCol)">
+                      <!-- input と班長の星を1つのドラッグ単位にまとめる。
+                           こうしないとSortableJSのswapでinputだけが入れ替わり、星が取り残されてしまう -->
+                      <div class="sortable-item square" style="position: relative;">
+                        <input type="text" class="sortable-item" readonly
+                          :class="['seat', getColorByName(nextSeatsTable[nextIndexRow][nextIndexCol], 1, 1)]"
+                          style="text-align: center;  resize: none; word-break: keep-all; vertical-align: top; font-size: 22px; font-weight: 600;"
+                          :value="nextSeatsTable[nextIndexRow][nextIndexCol]">
+                        <v-icon
+                          v-if="nextSeatsTable[nextIndexRow][nextIndexCol] && leaderConditions.includes(nextSeatsTable[nextIndexRow][nextIndexCol])"
+                          color="#F9A825"
+                          style="position: absolute; top: 4px; left: 4px; font-size: 24px; pointer-events: none;">mdi-star</v-icon>
+                      </div>
                     </span>
                     <span :class="{'margin-right': (nextIndexCol+1)%groupSizeX==0 && (nextIndexCol+1)!=seatsSizeX}"
                       :key="'nextSeatsSpan' + (nextIndexRow*seatsSizeX+nextIndexCol)"></span>

--- a/tests/drag-star.spec.js
+++ b/tests/drag-star.spec.js
@@ -1,0 +1,77 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const INDEX_HTML = `file://${path.resolve(__dirname, '../index.html')}`;
+
+// 班長Aと非班長Bをドラッグ＆ドロップで並び替えたとき、星(☆)が
+// 名前(A)に追従するかを検証するリグレッションテスト。
+// SortableJS(swap:true)は各セル(span)の「直接の子=ドラッグ可能アイテム」を
+// コンテナ間で入れ替えるため、その挙動をDOM操作で直接再現して確認する。
+test('班長Aを非班長Bと並び替えても星は班長Aに付いたままになる', async ({ page }) => {
+  await page.goto(INDEX_HTML, { waitUntil: 'networkidle' });
+  await page.evaluate(() => { app.setDemoData(); });
+  await page.waitForTimeout(100);
+
+  await page.evaluate(() => {
+    app.leaderConditions = ['山田'];
+    app.landing = false;
+    app.drawer = false;
+    app.showNewFeatureModal = false;
+    app.updateInformation = false;
+  });
+  await page.waitForTimeout(50);
+  await page.evaluate(() => { app.changeSeats(); app.drawer = false; });
+  await page.waitForTimeout(300);
+
+  // 班長(山田)の位置を取得
+  const pos = await page.evaluate(() => {
+    for (let r = 0; r < app.nextSeatsTable.length; r++)
+      for (let c = 0; c < app.nextSeatsTable[r].length; c++)
+        if (app.nextSeatsTable[r][c] === '山田') return [r, c];
+    return null;
+  });
+  expect(pos).not.toBeNull();
+  const [r, c] = pos;
+
+  // 同じ行にいる別の生徒（非班長）を入れ替え相手に選ぶ
+  const target = await page.evaluate(({ r, c }) => {
+    const seats = app.nextSeatsTable;
+    for (let cc = 0; cc < seats[r].length; cc++) {
+      if (cc !== c && seats[r][cc] && seats[r][cc] !== '山田') return [r, cc];
+    }
+    return null;
+  }, { r, c });
+  expect(target).not.toBeNull();
+  const [tr, tc] = target;
+
+  // SortableJS swap:true の入れ替えを再現
+  await page.evaluate(({ r, c, tr, tc }) => {
+    const fromSpan = document.getElementById(`nextSeatsRow-${r}-${c}`);
+    const toSpan = document.getElementById(`nextSeatsRow-${tr}-${tc}`);
+    const fromItem = fromSpan.firstElementChild;
+    const toItem = toSpan.firstElementChild;
+    const ph = document.createComment('ph');
+    fromItem.replaceWith(ph);
+    toItem.replaceWith(fromItem);
+    ph.replaceWith(toItem);
+  }, { r, c, tr, tc });
+  await page.waitForTimeout(200);
+
+  const after = await page.evaluate(({ r, c, tr, tc }) => {
+    function cellInfo(rr, cc) {
+      const span = document.getElementById(`nextSeatsRow-${rr}-${cc}`);
+      const input = span.querySelector('input');
+      const star = span.querySelector('.mdi-star');
+      return { name: input ? input.value : null, hasStar: !!star };
+    }
+    return { fromCell: cellInfo(r, c), toCell: cellInfo(tr, tc) };
+  }, { r, c, tr, tc });
+
+  // 星は「山田」と表示されているセルに付いていなければならない
+  const yamadaCell = after.fromCell.name === '山田' ? after.fromCell : after.toCell;
+  const otherCell = after.fromCell.name === '山田' ? after.toCell : after.fromCell;
+
+  expect(yamadaCell.name).toBe('山田');
+  expect(yamadaCell.hasStar).toBe(true);
+  expect(otherCell.hasStar).toBe(false);
+});


### PR DESCRIPTION
## 概要
班長(☆)に指定した生徒Aを、班長ではない生徒Bとドラッグ&ドロップで並び替えると、星がAではなくBに付いてしまう不具合を修正します。

## 原因
席替え後の各セル(`span`)はSortableJSのコンテナになっており、その中に `input`(名前) と `v-icon`(星) が**並んだ2つの子要素**として置かれていました。SortableJSの `swap` はコンテナ内のドラッグ可能な子要素を入れ替えるため、ドラッグした `input` だけが移動し、**星が元のセルに取り残されて**いました。

## 修正内容
- `input` と星を**1つのラッパー `div` にまとめ**、ドラッグ単位を1つにすることで、名前と星が必ず一緒に移動するようにしました。
- 星の絶対配置基準(`position: relative`)をラッパーへ移し、星に `pointer-events: none` を付与（星の角を掴んでもドラッグ可能に）。
- `swapClass: 'highlighted'` がラッパーに付くようになるため、前面の不透明な `input` にもハイライト色が反映されるよう `.highlighted input` のCSSを追加（ドラッグ中のスワップ先ハイライトが見えなくなる副次的なデグレを防止）。

## テスト
- リグレッションテスト `tests/drag-star.spec.js` を追加。
  - **修正前のコードでは失敗**（星が相手に付くことを検出）、**修正後は成功**することを確認済み。
- 既存テストを含む全31件がパス。
- `forceFallback` を注入した**実マウスドラッグ**でも、スワップ発生・星追従・再席替え後の整合を確認済み。

## 検証した「デグレなし」項目
- ボックス寸法/垂直位置: ラッパー・inputがセルを完全充填（gap 0px）
- `setSortableJS`/`onEnd`/`reverseSeats` はセルのidに依存し内部構造に非依存 → 影響なし
- 新規CSS `.highlighted input` は next-seats のみに作用（「今の座席」には影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)