### PR TITLE
setBlankDataが座席サイズをハードコードしている問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -1464,19 +1464,11 @@
           this.countSeats();
           this.leaderConditions = ['別本', '平野', '高松', '岡村', '四十住', '長島'];
         },
-        setBlankData() {
-          this.seatsTable.splice(0, 1, ['', '', '', '', '', '']);
-          this.seatsTable.splice(1, 1, ['', '', '', '', '', '']);
-          this.seatsTable.splice(2, 1, ['', '', '', '', '', '']);
-          this.seatsTable.splice(3, 1, ['', '', '', '', '', '']);
-          this.seatsTable.splice(4, 1, ['', '', '', '', '', '']);
-          this.seatsTable.splice(5, 1, ['', '', '', '', '', '']);
-          this.genderTable.splice(0, 1, ['', '', '', '', '', '']);
-          this.genderTable.splice(1, 1, ['', '', '', '', '', '']);
-          this.genderTable.splice(2, 1, ['', '', '', '', '', '']);
-          this.genderTable.splice(3, 1, ['', '', '', '', '', '']);
-          this.genderTable.splice(4, 1, ['', '', '', '', '', '']);
-          this.genderTable.splice(5, 1, ['', '', '', '', '', '']);
+        setBlankData() { // 座席・性別テーブルを現在のサイズで空にする
+          for (let i = 0; i < this.seatsSizeY; i++) {
+            this.seatsTable.splice(i, 1, Array(this.seatsSizeX).fill(''));
+            this.genderTable.splice(i, 1, Array(this.seatsSizeX).fill(''));
+          }
           this.countSeats();
         },
         uniqueKey(value, nextIndexRow, nextIndexCol) {


### PR DESCRIPTION
## 概要
`setBlankData()` が座席・性別テーブルの行を6×6前提でベタ書きしていたため、`seatsSizeX/Y` が6以外のときにテーブルと座席サイズが不整合になりうる問題を修正しました。

## 変更内容
- 12行のハードコードされた `splice` を、現在の `seatsSizeY`/`seatsSizeX` に追従するループに置き換え
- 既存の [applyExcelPasteData](index.html#L1428) / [resetNextSeatsTable](index.html#L1644) と同じ `splice(i, 1, Array(this.seatsSizeX).fill(''))` の書き方に統一

```js
setBlankData() { // 座席・性別テーブルを現在のサイズで空にする
  for (let i = 0; i < this.seatsSizeY; i++) {
    this.seatsTable.splice(i, 1, Array(this.seatsSizeX).fill(''));
    this.genderTable.splice(i, 1, Array(this.seatsSizeX).fill(''));
  }
  this.countSeats();
},
```

## 補足
`setBlankData()` はチュートリアル完了時（`startTutorial` の `oncomplete`）に呼ばれます。チュートリアルは直前に6×6へ設定するため現状の実害は限定的ですが、サイズ非依存にすることで将来的な不整合を防ぎます。

## 検証
- `node --check` で構文OK
- Playwright 全31テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)