### PR TITLE
checkNear/checkFarのNaN比較への暗黙依存を明示化

### DIFF
--- a/index.html
+++ b/index.html
@@ -2055,6 +2055,7 @@
               // ----ここまで----
               const distance = nearConditionArray[2] + 1; // 距離、表記とのズレを修正するために+1
               const nearStudentPosition = this.getPositionFromNextSeatsTable(nearStudentName); // すでに配置されていればその座標、まだ配置されてなければfalse
+              if (nearStudentPosition === false) return; // 相手がまだ配置されていなければ、ここでは距離を判定しない（相手を配置する際に改めてチェックされる）
               if (this.maxDistance(p, nearStudentPosition) > distance) { // 距離のmaxが条件distanceより上なら返り値をfalseに更新
                 returnValue = false;
               }
@@ -2076,6 +2077,7 @@
               // ----ここまで----
               const distance = farConditionArray[2] + 1; // 距離、表記とのズレを修正するために+1
               const farStudentPosition = this.getPositionFromNextSeatsTable(farStudentName); // すでに配置されていればその座標、まだ配置されてなければfalse
+              if (farStudentPosition === false) return; // 相手がまだ配置されていなければ、ここでは距離を判定しない（相手を配置する際に改めてチェックされる）
               if (this.maxDistance(p, farStudentPosition) < distance) { // 距離のminが条件distanceより下なら返り値をfalseに更新
                 returnValue = false;
               }


### PR DESCRIPTION
## 概要
`checkNear` / `checkFar` が、近づける/離す相手の生徒が**まだ配置されていない**ケースを「NaN比較が常にfalseになる」という暗黙的な副作用に頼って処理していた問題を、明示的なコードに修正しました。挙動は不変です。

## 背景（修正前の暗黙依存）
- 相手が未配置のとき `getPositionFromNextSeatsTable` は `false` を返す
- `maxDistance(p, false)` は `false[0]` が `undefined` のため `NaN` を返す
- `NaN > distance`（near）/ `NaN < distance`（far）はどちらも `false` になり、結果的に距離チェックがスキップされていた

動作はするものの、意図が読み取れず壊れやすい実装でした。

## 変更内容
両メソッドに、相手が未配置なら距離判定をスキップする early return を追加：

```js
const nearStudentPosition = this.getPositionFromNextSeatsTable(nearStudentName);
if (nearStudentPosition === false) return; // 相手がまだ配置されていなければ、ここでは距離を判定しない（相手を配置する際に改めてチェックされる）
if (this.maxDistance(p, nearStudentPosition) > distance) {
  returnValue = false;
}
```

- 修正前と完全に同じ挙動（未配置時はスキップ）を、明示的に表現
- `maxDistance` は常に座標2点で呼ばれるようになり、`NaN` が発生しなくなる

## 検証
- `node --check` 構文OK
- Playwright 全31テスト合格（near/far/combined を含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)