### PR TITLE
前後の行固定で座席が尽きたときのクラッシュを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -1833,8 +1833,9 @@
           this.shuffle(this.dupBackTwoRowsSeatsIndex);
           this.backTwoRowsConditions.forEach(backTwoRowsStudentName => {
             if (this.getPositionFromNextSeatsTable(backTwoRowsStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
-            if (!this.dupBackTwoRowsSeatsIndex.length) {
-              // todo エラーを表示してbreak
+            if (!this.dupBackTwoRowsSeatsIndex.length) { // 後ろ2列に空き座席が残っていなければ配置できないので、restartFlagを立てて最初からやり直す（undefinedをshiftしてクラッシュするのを防ぐ）
+              this.restartFlag = true;
+              return;
             }
             let topIndex = this.dupBackTwoRowsSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
             // ----近づける/離す/性別/異なる座席チェック----

--- a/index.html
+++ b/index.html
@@ -1765,6 +1765,10 @@
           this.shuffle(this.dupFrontSeatsIndex);
           this.frontConditions.forEach(frontStudentName => {
             if (this.getPositionFromNextSeatsTable(frontStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
+            if (!this.dupFrontSeatsIndex.length) { // 最前列に空き座席が残っていなければ配置できないので、restartFlagを立てて最初からやり直す（undefinedをshiftしてクラッシュするのを防ぐ）
+              this.restartFlag = true;
+              return;
+            }
             let topIndex = this.dupFrontSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
             // ----近づける/離す/性別/異なる座席チェック----
             while (!this.checkNear(frontStudentName, topIndex) || !this.checkFar(frontStudentName, topIndex) || (this.isFixGender && !this.checkGender(frontStudentName, topIndex)) || (this.isAllDifferent && !this.checkDifferent(frontStudentName, topIndex))) { // いずれかの条件を満たさない間、繰り返す
@@ -1788,6 +1792,10 @@
           this.shuffle(this.dupFrontTwoRowsSeatsIndex);
           this.frontTwoRowsConditions.forEach(frontTwoRowsStudentName => {
             if (this.getPositionFromNextSeatsTable(frontTwoRowsStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
+            if (!this.dupFrontTwoRowsSeatsIndex.length) { // 前2列に空き座席が残っていなければ配置できないので、restartFlagを立てて最初からやり直す（undefinedをshiftしてクラッシュするのを防ぐ）
+              this.restartFlag = true;
+              return;
+            }
             let topIndex = this.dupFrontTwoRowsSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
             // ----近づける/離す/性別/異なる座席チェック----
             while (!this.checkNear(frontTwoRowsStudentName, topIndex) || !this.checkFar(frontTwoRowsStudentName, topIndex) || (this.isFixGender && !this.checkGender(frontTwoRowsStudentName, topIndex)) || (this.isAllDifferent && !this.checkDifferent(frontTwoRowsStudentName, topIndex))) { // いずれかの条件を満たさない間、繰り返す
@@ -1810,6 +1818,10 @@
           this.shuffle(this.dupBackSeatsIndex);
           this.backConditions.forEach(backStudentName => {
             if (this.getPositionFromNextSeatsTable(backStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
+            if (!this.dupBackSeatsIndex.length) { // 最後列に空き座席が残っていなければ配置できないので、restartFlagを立てて最初からやり直す（undefinedをshiftしてクラッシュするのを防ぐ）
+              this.restartFlag = true;
+              return;
+            }
             let topIndex = this.dupBackSeatsIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
             // ----近づける/離す/性別/異なる座席チェック----
             while (!this.checkNear(backStudentName, topIndex) || !this.checkFar(backStudentName, topIndex) || (this.isFixGender && !this.checkGender(backStudentName, topIndex)) || (this.isAllDifferent && !this.checkDifferent(backStudentName, topIndex))) { // いずれかの条件を満たさない間、繰り返す

--- a/tests/back-condition.spec.js
+++ b/tests/back-condition.spec.js
@@ -104,4 +104,23 @@ test.describe('後ろから2列目以内に固定（backTwoRowsConditions）', (
       }
     }
   });
+
+  test('後ろ2列の座席数を超える人数を固定 → クラッシュせずエラー扱いになる', async ({ page }) => {
+    // 6×6では後ろ2列の座席は12席。13人を固定すると配置不能になり、
+    // 修正前は空配列をshiftしてundefinedを参照しクラッシュしていた。
+    const names = ['別本', '山田', '平野', '山口', '高松', '寺井', '山村', '坂本', '浦山', '栗原', '谷井', '柳澤', '中川'];
+    const result = await page.evaluate((names) => {
+      app.backTwoRowsConditions = names;
+      let threw = false;
+      try {
+        app.changeSeats();
+      } catch (e) {
+        threw = true;
+      }
+      return { threw, error: app.error };
+    }, names);
+
+    expect(result.threw).toBe(false); // クラッシュしない
+    expect(result.error).toBe(true);  // 配置不能なのでエラー表示になる
+  });
 });

--- a/tests/back-condition.spec.js
+++ b/tests/back-condition.spec.js
@@ -64,6 +64,25 @@ test.describe('後ろに固定（backConditions）', () => {
       }
     }
   });
+
+  test('最後列の座席数を超える人数を固定 → クラッシュせずエラー扱いになる', async ({ page }) => {
+    // 6×6では最後列は6席。7人を固定すると配置不能になり、
+    // 修正前は空配列をshiftしてundefinedを参照しクラッシュしていた。
+    const names = ['別本', '山田', '平野', '山口', '高松', '寺井', '山村'];
+    const result = await page.evaluate((names) => {
+      app.backConditions = names;
+      let threw = false;
+      try {
+        app.changeSeats();
+      } catch (e) {
+        threw = true;
+      }
+      return { threw, error: app.error };
+    }, names);
+
+    expect(result.threw).toBe(false);
+    expect(result.error).toBe(true);
+  });
 });
 
 test.describe('後ろから2列目以内に固定（backTwoRowsConditions）', () => {

--- a/tests/front-condition.spec.js
+++ b/tests/front-condition.spec.js
@@ -62,6 +62,25 @@ test.describe('前に固定（frontConditions）', () => {
       }
     }
   });
+
+  test('最前列の座席数を超える人数を固定 → クラッシュせずエラー扱いになる', async ({ page }) => {
+    // 6×6では最前列は6席。7人を固定すると配置不能になり、
+    // 修正前は空配列をshiftしてundefinedを参照しクラッシュしていた。
+    const names = ['別本', '山田', '平野', '山口', '高松', '寺井', '山村'];
+    const result = await page.evaluate((names) => {
+      app.frontConditions = names;
+      let threw = false;
+      try {
+        app.changeSeats();
+      } catch (e) {
+        threw = true;
+      }
+      return { threw, error: app.error };
+    }, names);
+
+    expect(result.threw).toBe(false);
+    expect(result.error).toBe(true);
+  });
 });
 
 test.describe('前から2列目以内に固定（frontTwoRowsConditions）', () => {
@@ -99,5 +118,24 @@ test.describe('前から2列目以内に固定（frontTwoRowsConditions）', () 
         expect(pos[1]).toBeLessThanOrEqual(1);
       }
     }
+  });
+
+  test('前2列の座席数を超える人数を固定 → クラッシュせずエラー扱いになる', async ({ page }) => {
+    // 6×6では前2列の座席は12席。13人を固定すると配置不能になり、
+    // 修正前は空配列をshiftしてundefinedを参照しクラッシュしていた。
+    const names = ['別本', '山田', '平野', '山口', '高松', '寺井', '山村', '坂本', '浦山', '栗原', '谷井', '柳澤', '中川'];
+    const result = await page.evaluate((names) => {
+      app.frontTwoRowsConditions = names;
+      let threw = false;
+      try {
+        app.changeSeats();
+      } catch (e) {
+        threw = true;
+      }
+      return { threw, error: app.error };
+    }, names);
+
+    expect(result.threw).toBe(false);
+    expect(result.error).toBe(true);
   });
 });


### PR DESCRIPTION
## 概要
行固定（最前列 / 前2列 / 最後列 / 後ろ2列）の配置メソッドで、固定する生徒数が対象の座席数を超えると**クラッシュ**していた問題を修正しました。当初は後ろ2列のみ（#2）の対応でしたが、同種の不具合が他の3メソッドにも存在したため併せて修正しています。

## 不具合の内容
`changeBackTwoRowsSeats()` の空座席ガードが未実装（TODOコメントのみ）で、さらに `changeFrontSeats` / `changeFrontTwoRowsSeats` / `changeBackSeats` には初回 `shift()` の空ガードが**そもそも無い**状態でした。

```js
let topIndex = this.dupBackTwoRowsSeatsIndex.shift(); // 空配列なら undefined
```
座席が尽きると `shift()` が `undefined` を返し、直後の `checkNear(name, undefined)` や `this.nextSeatsTable[topIndex[1]]` で `undefined` を参照して例外が発生していました。

例: 6×6（最前列=6席 / 前2列=12席 / 最後列=6席 / 後ろ2列=12席）で、それぞれの座席数を超える人数を該当の行固定に指定したケース、あるいは行固定どうしの併用で座席が競合したケースで発生します。

## 変更内容
4メソッドすべてに、`placeLeaders()` 等と同じ「配置不能なら `restartFlag` を立てて最初からやり直す」ガードを追加：

```js
if (!this.dupFrontSeatsIndex.length) { // 空き座席が残っていなければ配置できないので、restartFlagを立てて最初からやり直す（undefinedをshiftしてクラッシュするのを防ぐ）
  this.restartFlag = true;
  return;
}
```
リトライしても配置できない場合は、既存のループ上限（500回）により最終的にエラーダイアログが表示されます。

## 回帰テスト
4ケースを追加（最前列 / 前2列 / 最後列 / 後ろ2列）。いずれも「座席数を超える人数を固定 → クラッシュせず `app.error === true` になる」ことを検証。
- **修正前**: `app.changeSeats()` が例外を投げてテスト失敗（4メソッドとも再現確認済み）
- **修正後**: 例外なく完了しエラー扱いになることを確認

## 検証
- `node --check` 構文OK
- Playwright 全35テスト合格（新規4件含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)