### PR TITLE
席替え実行時に前回のエラー表示をリセット

### DIFF
--- a/index.html
+++ b/index.html
@@ -1638,6 +1638,7 @@
           }
         },
         changeSeats() { // メイン処理
+          this.error = false; // 前回の実行で出したエラー表示を解除し、毎回クリーンな状態から始める
           let loopNum = 0; // changeSeats()の処理を指定された回数繰り返す際に制御する変数
           do {
             loopNum += 1;

--- a/tests/back-condition.spec.js
+++ b/tests/back-condition.spec.js
@@ -83,6 +83,23 @@ test.describe('後ろに固定（backConditions）', () => {
     expect(result.threw).toBe(false);
     expect(result.error).toBe(true);
   });
+
+  test('配置不能で出たエラーが、次の実現可能な席替えで解除される', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      // まず配置不能な条件（最後列6席に7人）でエラーを出す
+      app.backConditions = ['別本', '山田', '平野', '山口', '高松', '寺井', '山村'];
+      app.changeSeats();
+      const errorAfterInfeasible = app.error;
+      // 次に実現可能な条件で席替えする
+      app.backConditions = ['山田'];
+      app.changeSeats();
+      const errorAfterFeasible = app.error;
+      return { errorAfterInfeasible, errorAfterFeasible };
+    });
+
+    expect(result.errorAfterInfeasible).toBe(true);  // 配置不能時はエラー
+    expect(result.errorAfterFeasible).toBe(false);   // 修正前はtrueのまま残っていた
+  });
 });
 
 test.describe('後ろから2列目以内に固定（backTwoRowsConditions）', () => {


### PR DESCRIPTION
## 概要
`changeSeats()` が `error` を `true` にするだけで `false` に戻していなかったため、一度「配置不能」エラーが出ると、その後に実現可能な条件で席替えしてもエラーダイアログが表示されたまま残りうる問題を修正しました。

## 変更内容
`changeSeats()` の冒頭で `error` をリセットし、毎回クリーンな状態から始めるようにしました。

```js
changeSeats() { // メイン処理
  this.error = false; // 前回の実行で出したエラー表示を解除し、毎回クリーンな状態から始める
  let loopNum = 0;
  ...
```

## 回帰テスト
`tests/back-condition.spec.js` に「配置不能で出たエラーが、次の実現可能な席替えで解除される」を追加。
- **修正前**: 2回目（実現可能）の後も `app.error === true` のまま → テスト失敗（再現確認済み）
- **修正後**: `app.error === false` に解除される

## 検証
- `node --check` 構文OK
- Playwright 全36テスト合格（新規1件含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)