### PR TITLE
同名の生徒に関する不具合をまとめて修正（表示・席替え）

### DIFF
--- a/index.html
+++ b/index.html
@@ -1568,28 +1568,6 @@
             this.leaderConditions.push('');
           }
         },
-        getColorByName(studentName, col, row) { // 座席の種類に応じた色を返す
-          const genderIndex = this.studentsName.indexOf(studentName); // 生徒名に対応する性別を取得
-          let gender
-          if (genderIndex === -1) { //
-            gender = ''
-          } else {
-            gender = this.genderArray[genderIndex];
-          }
-          if (gender === '') {
-            if (row === 0 && col === 0) {
-              return 'male-seats'
-            } else if (row === 0 && col === 1) {
-              return 'female-seats'
-            } else {
-              return 'off-seats'
-            }
-          } else if (gender === 'male') {
-            return 'male-seats'
-          } else if (gender === 'female') {
-            return 'female-seats'
-          } else return 'on-seats'
-        },
         getColorBySeat(col, row) { // 入力テーブルの座席色を、その座席の性別（座標）から直接決める。同名の生徒がいても座席ごとに正しく判定できる
           const gender = this.genderTable[row][col];
           if (gender === 'male') {
@@ -1605,19 +1583,23 @@
           }
         },
         getColorByNextSeat(name, col, row) { // 席替え後（結果テーブル）の座席色を返す
+          let gender;
           if (this.isFixGender) {
-            // 性別固定中は、その席に座る生徒の性別＝その席に設定された性別なので座標から判定する。
+            // 性別固定中は「その席に座る生徒の性別＝その席に設定された性別」なので座標から判定する。
             // これなら同名の生徒（例: 男の山田と女の山田）でも席ごとに正しい色になる。
-            const gender = this.genderTable[row][col];
-            if (gender === 'male') {
-              return 'male-seats'
-            } else if (gender === 'female') {
-              return 'female-seats'
-            } else {
-              return 'off-seats'
-            }
+            gender = this.genderTable[row][col];
+          } else {
+            // 性別固定OFF時は座席で性別が決まらないため、生徒の性別を名前から引く（同名は1人目基準）。
+            const genderIndex = this.studentsName.indexOf(name);
+            gender = genderIndex === -1 ? '' : this.genderArray[genderIndex];
           }
-          return this.getColorByName(name, 1, 1); // 性別固定OFF時は生徒の性別を名前から引く（従来どおり）
+          if (gender === 'male') {
+            return 'male-seats'
+          } else if (gender === 'female') {
+            return 'female-seats'
+          } else {
+            return 'off-seats'
+          }
         },
         toggleGender(col, row) {
           if (this.genderTable[row][col] === 'male') {

--- a/index.html
+++ b/index.html
@@ -1472,13 +1472,19 @@
           this.countSeats();
         },
         uniqueKey(value, nextIndexRow, nextIndexCol) {
-          let key
           if (value === '') {
-            key = `nextSeatsRow-${nextIndexRow}-${nextIndexCol}`;
-          } else {
-            key = value;
+            return `nextSeatsRow-${nextIndexRow}-${nextIndexCol}`; // 空席は座標でキーを作る
           }
-          return key;
+          // 同名の生徒がいてもキーが衝突しないよう、この座席までに同名が何回出現したかを付与する。
+          // 一意な名前なら常に「名前#0」になり、席替え前後でキーが安定するため移動アニメーションがそのまま効く。
+          let occurrence = 0;
+          for (let row = 0; row <= nextIndexRow; row++) {
+            const lastCol = row === nextIndexRow ? nextIndexCol : this.nextSeatsTable[row].length;
+            for (let col = 0; col < lastCol; col++) {
+              if (this.nextSeatsTable[row][col] === value) occurrence += 1;
+            }
+          }
+          return `${value}#${occurrence}`;
         },
         beforeChangeSeats() { // トランジションのズレをなくすために、スワップされていたら席替え直前に、次の座席テーブルに反映する
           if (isReverseSeats) {

--- a/index.html
+++ b/index.html
@@ -1717,9 +1717,24 @@
         },
         shuffleSeats() { // 条件のない生徒を席替え
           this.shuffle(this.dupSeatsTableIndex); // インデックスをシャッフル
-          this.dupStudentsName.forEach(dupStudentName => { // 生徒を一人取り出す
+          // 残った生徒に、元の並び（studentsName/genderArray/seatsTableIndex）から性別と元座席を割り当てる。
+          // 同名の生徒がいても元インデックスを1人ずつ消費するので、性別や元座席を取り違えない（例: 男の山田と女の山田）。
+          const usedOriginalIndex = new Set();
+          const remainingStudents = this.dupStudentsName.map(name => {
+            let originalIndex = -1;
+            for (let i = 0; i < this.studentsName.length; i++) {
+              if (!usedOriginalIndex.has(i) && this.studentsName[i] === name) {
+                usedOriginalIndex.add(i);
+                originalIndex = i;
+                break;
+              }
+            }
+            return { name, gender: this.genderArray[originalIndex], originalSeat: this.seatsTableIndex[originalIndex] };
+          });
+          remainingStudents.forEach(student => { // 生徒を一人取り出す
             let topIndex = this.dupSeatsTableIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
-            while ((this.isFixGender && !this.checkGender(dupStudentName, topIndex)) || (this.isAllDifferent && !this.checkDifferent(dupStudentName, topIndex))) { // 条件を満たさない間、繰り返す
+            // 性別固定: 座席の性別が生徒の性別と一致するか／異なる席: 元の座席と違うか。満たさない間、別の座席を試す
+            while ((this.isFixGender && this.genderTable[topIndex[1]][topIndex[0]] !== student.gender) || (this.isAllDifferent && student.originalSeat.toString() === topIndex.toString())) {
               if (this.calcNum > this.seatsNum) {
                 this.restartFlag = true;
                 break;
@@ -1728,10 +1743,8 @@
               topIndex = this.dupSeatsTableIndex.shift(); // 配列先頭のインデックスを再度取り出す
               this.calcNum += 1;
             }
-            this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, dupStudentName); // 取り出したインデックスの位置に生徒名を保存
-            const genderIndex = this.studentsName.indexOf(dupStudentName); // 生徒名に対応する性別のインデックスを取得
-            const gender = this.genderArray[genderIndex]; // 生徒名に対応する性別を取得
-            this.nextGenderTable[topIndex[1]].splice(topIndex[0], 1, gender);// 復元用のnextGenderTableに席替え後の性別を保存
+            this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, student.name); // 取り出したインデックスの位置に生徒名を保存
+            this.nextGenderTable[topIndex[1]].splice(topIndex[0], 1, student.gender); // 復元用のnextGenderTableに席替え後の性別を保存
           })
         },
         shuffle(array) { // 配列をランダムにシャッフル

--- a/index.html
+++ b/index.html
@@ -1017,21 +1017,21 @@
               <span v-for="( seat, indexCol ) in seats" class="minus-margin-right">
                 <!-- 1つ目のフォームにプレイスホルダーを設定 -->
                 <input type="text" v-if="indexRow==0 && indexCol==0"
-                  :class="['seat', getColorByName(seatsTable[indexRow][indexCol], indexCol, indexRow)]"
+                  :class="['seat', getColorBySeat(indexCol, indexRow)]"
                   @input="writeStudentName( indexCol, indexRow, $event.target.value ); countSeats();"
                   :key="indexRow.toString() + indexCol.toString()"
                   style="text-align: center;  resize: none; word-break: keep-all; vertical-align: top; font-size: 22px; font-weight: 600;"
                   :value="seatsTable[indexRow][indexCol]" @click="toggleGender(indexCol,indexRow)" placeholder="安藤">
                 <!-- 2つ目のフォームにプレイスホルダーを設定 -->
                 <input type="text" v-else-if="indexRow==0 && indexCol==1"
-                  :class="['seat', getColorByName(seatsTable[indexRow][indexCol], indexCol, indexRow)]"
+                  :class="['seat', getColorBySeat(indexCol, indexRow)]"
                   @input="writeStudentName( indexCol, indexRow, $event.target.value ); countSeats();"
                   :key="indexRow.toString() + indexCol.toString()"
                   style="text-align: center;  resize: none; word-break: keep-all; vertical-align: top; font-size: 22px; font-weight: 600;"
                   :value="seatsTable[indexRow][indexCol]" @click="toggleGender(indexCol,indexRow)" placeholder="石原">
                 <!-- 3つ目以降のフォーム -->
                 <input type="text" v-else
-                  :class="['seat', getColorByName(seatsTable[indexRow][indexCol], indexCol, indexRow)]"
+                  :class="['seat', getColorBySeat(indexCol, indexRow)]"
                   @input="writeStudentName( indexCol, indexRow, $event.target.value ); countSeats();"
                   :key="indexRow.toString() + indexCol.toString()"
                   style="text-align: center;  resize: none; word-break: keep-all; vertical-align: top; font-size: 22px; font-weight: 600;"
@@ -1589,6 +1589,20 @@
           } else if (gender === 'female') {
             return 'female-seats'
           } else return 'on-seats'
+        },
+        getColorBySeat(col, row) { // 入力テーブルの座席色を、その座席の性別（座標）から直接決める。同名の生徒がいても座席ごとに正しく判定できる
+          const gender = this.genderTable[row][col];
+          if (gender === 'male') {
+            return 'male-seats'
+          } else if (gender === 'female') {
+            return 'female-seats'
+          } else if (row === 0 && col === 0) { // 空席のうち左上はデモ用に男子色
+            return 'male-seats'
+          } else if (row === 0 && col === 1) { // その隣はデモ用に女子色
+            return 'female-seats'
+          } else {
+            return 'off-seats'
+          }
         },
         toggleGender(col, row) {
           if (this.genderTable[row][col] === 'male') {

--- a/index.html
+++ b/index.html
@@ -1077,7 +1077,7 @@
                            こうしないとSortableJSのswapでinputだけが入れ替わり、星が取り残されてしまう -->
                       <div class="sortable-item square" style="position: relative;">
                         <input type="text" class="sortable-item" readonly
-                          :class="['seat', getColorByName(nextSeatsTable[nextIndexRow][nextIndexCol], 1, 1)]"
+                          :class="['seat', getColorByNextSeat(nextSeatsTable[nextIndexRow][nextIndexCol], nextIndexCol, nextIndexRow)]"
                           style="text-align: center;  resize: none; word-break: keep-all; vertical-align: top; font-size: 22px; font-weight: 600;"
                           :value="nextSeatsTable[nextIndexRow][nextIndexCol]">
                         <v-icon
@@ -1603,6 +1603,21 @@
           } else {
             return 'off-seats'
           }
+        },
+        getColorByNextSeat(name, col, row) { // 席替え後（結果テーブル）の座席色を返す
+          if (this.isFixGender) {
+            // 性別固定中は、その席に座る生徒の性別＝その席に設定された性別なので座標から判定する。
+            // これなら同名の生徒（例: 男の山田と女の山田）でも席ごとに正しい色になる。
+            const gender = this.genderTable[row][col];
+            if (gender === 'male') {
+              return 'male-seats'
+            } else if (gender === 'female') {
+              return 'female-seats'
+            } else {
+              return 'off-seats'
+            }
+          }
+          return this.getColorByName(name, 1, 1); // 性別固定OFF時は生徒の性別を名前から引く（従来どおり）
         },
         toggleGender(col, row) {
           if (this.genderTable[row][col] === 'male') {

--- a/tests/duplicate-name-gender.spec.js
+++ b/tests/duplicate-name-gender.spec.js
@@ -45,4 +45,34 @@ test.describe('同名・異性別の生徒（性別固定）', () => {
       expect(result.names).toEqual(['佐藤', '山田', '山田', '鈴木'].sort());
     }
   });
+
+  test('席替え後の結果テーブルで、2人の山田が男女それぞれの色で表示される', async ({ page }) => {
+    await page.evaluate(() => {
+      app.seatsTable.splice(0, 1, ['山田', '佐藤', '', '', '', '']);
+      app.seatsTable.splice(1, 1, ['山田', '鈴木', '', '', '', '']);
+      app.genderTable.splice(0, 1, ['male', 'female', '', '', '', '']);
+      app.genderTable.splice(1, 1, ['female', 'male', '', '', '', '']);
+      app.countSeats();
+    });
+    await page.waitForTimeout(150);
+
+    for (let i = 0; i < 10; i++) {
+      const result = await page.evaluate(() => {
+        app.error = false;
+        app.changeSeats();
+        // 結果テーブルの山田2人の色クラスを、配置座標から取得
+        const colors = [];
+        for (let r = 0; r < 2; r++) {
+          for (let c = 0; c < 2; c++) {
+            if (app.nextSeatsTable[r][c] === '山田') {
+              colors.push(app.getColorByNextSeat('山田', c, r));
+            }
+          }
+        }
+        return colors.sort();
+      });
+      // 修正前は ['male-seats','male-seats']（両方とも1人目=男で表示）になっていた
+      expect(result).toEqual(['female-seats', 'male-seats']);
+    }
+  });
 });

--- a/tests/duplicate-name-gender.spec.js
+++ b/tests/duplicate-name-gender.spec.js
@@ -1,0 +1,48 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const INDEX_HTML = `file://${path.resolve(__dirname, '../index.html')}`;
+
+test.describe('同名・異性別の生徒（性別固定）', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(INDEX_HTML, { waitUntil: 'networkidle' });
+  });
+
+  test('男の山田と女の山田がいても席替えがエラーにならず、性別配置が保たれる', async ({ page }) => {
+    await page.evaluate(() => {
+      // 男2(山田/鈴木) 女2(佐藤/山田)。山田は男女1人ずつ
+      app.seatsTable.splice(0, 1, ['山田', '佐藤', '', '', '', '']);
+      app.seatsTable.splice(1, 1, ['山田', '鈴木', '', '', '', '']);
+      app.genderTable.splice(0, 1, ['male', 'female', '', '', '', '']);
+      app.genderTable.splice(1, 1, ['female', 'male', '', '', '', '']);
+      app.countSeats();
+    });
+    await page.waitForTimeout(150); // watcherでstudentsName/genderArray/seatsTableIndexが更新されるのを待つ
+
+    for (let i = 0; i < 10; i++) {
+      const result = await page.evaluate(() => {
+        app.error = false;
+        app.changeSeats();
+        // 配置された各座席で、生徒の性別が座席の性別(genderTable)と一致しているか
+        let genderOk = true;
+        const names = [];
+        for (let row = 0; row < 2; row++) {
+          for (let col = 0; col < 2; col++) {
+            const name = app.nextSeatsTable[row][col];
+            names.push(name);
+            // nextGenderTable(配置後の性別)が、元のgenderTable(座席固定の性別)と一致
+            if (app.nextGenderTable[row][col] !== app.genderTable[row][col]) genderOk = false;
+          }
+        }
+        names.sort();
+        return { error: app.error, genderOk, names };
+      });
+
+      expect(result.error).toBe(false);   // 修正前はtrue（無限リスタート→エラー）
+      expect(result.genderOk).toBe(true); // 各席の性別が保たれている
+      // 4人全員が配置されている（同名の山田2人を含む）
+      expect(result.names).toEqual(['佐藤', '山田', '山田', '鈴木'].sort());
+    }
+  });
+});

--- a/tests/duplicate-name.spec.js
+++ b/tests/duplicate-name.spec.js
@@ -43,4 +43,28 @@ test.describe('同名の生徒（uniqueKey）', () => {
     expect(result.sato).toBe('佐藤#0');
     expect(result.empty).toBe('nextSeatsRow-0-1'); // 空席は座標ベース
   });
+
+  test('同名の生徒でも座席ごとにクリックで性別の色が切り替わる', async ({ page }) => {
+    // 2行目に「田中」を2人並べる（左上のデモ色セルを避ける）
+    await page.evaluate(() => {
+      app.seatsTable.splice(1, 1, ['田中', '田中', '', '', '', '']);
+      app.genderTable.splice(1, 1, ['male', 'male', '', '', '', '']);
+      app.countSeats();
+    });
+    await page.waitForTimeout(100);
+
+    // クリック相当：2人目（col=1, row=1）の性別をトグル
+    await page.evaluate(() => { app.toggleGender(1, 1); });
+    await page.waitForTimeout(100);
+
+    // 描画された入力テーブル2行目の各座席の色クラスを取得
+    const classes = await page.evaluate(() => {
+      const rows = document.querySelectorAll('.seats-scroll-container li');
+      const inputs = rows[1].querySelectorAll('input.seat');
+      return [inputs[0].className, inputs[1].className];
+    });
+
+    expect(classes[0]).toContain('male-seats');   // 1人目は変わらない
+    expect(classes[1]).toContain('female-seats'); // 修正前は male-seats のまま（1人目を参照していた）
+  });
 });

--- a/tests/duplicate-name.spec.js
+++ b/tests/duplicate-name.spec.js
@@ -1,0 +1,46 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const INDEX_HTML = `file://${path.resolve(__dirname, '../index.html')}`;
+
+test.describe('同名の生徒（uniqueKey）', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(INDEX_HTML, { waitUntil: 'networkidle' });
+  });
+
+  test('同名の生徒がいてもキーが衝突しない', async ({ page }) => {
+    const keys = await page.evaluate(() => {
+      // 「田中」「佐藤」を重複させた座席テーブル
+      app.nextSeatsTable = [
+        ['田中', '佐藤', '田中'],
+        ['佐藤', '鈴木', '田中'],
+      ];
+      const keys = [];
+      for (let row = 0; row < app.nextSeatsTable.length; row++) {
+        for (let col = 0; col < app.nextSeatsTable[row].length; col++) {
+          keys.push(app.uniqueKey(app.nextSeatsTable[row][col], row, col));
+        }
+      }
+      return keys;
+    });
+
+    // 修正前は同名のキーが衝突して重複していた
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  test('一意な名前は名前ベースのキー（#0）になりアニメーション追跡が保たれる', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      app.nextSeatsTable = [['山田', '', '佐藤']];
+      return {
+        yamada: app.uniqueKey('山田', 0, 0),
+        empty: app.uniqueKey('', 0, 1),
+        sato: app.uniqueKey('佐藤', 0, 2),
+      };
+    });
+
+    expect(result.yamada).toBe('山田#0');
+    expect(result.sato).toBe('佐藤#0');
+    expect(result.empty).toBe('nextSeatsRow-0-1'); // 空席は座標ベース
+  });
+});


### PR DESCRIPTION
## 概要
同姓・同名の生徒が複数いるときに発生する不具合を、**表示**と**席替え**の両面でまとめて修正します（旧 #309 を統合）。条件併用時のあいまいさは別スコープ（既知の制限）とします。

対象の3不具合：
1. **`:key` の衝突で描画が壊れる**（席替え結果テーブル）
2. **クリックしても性別の色が切り替わらない**（座席入力テーブル）
3. **男女の同名（例: 男の山田と女の山田）で席替えするとエラーになる**

## 修正1: :key 衝突
結果テーブルの `:key` に生徒名をそのまま使っていたため、同名で Vue のキーが衝突していた。`uniqueKey()` をその座席までの同名出現回数を付与する方式に変更（`名前#0` 形式）。
- 一意名は常に `名前#0` で安定 → 移動アニメーション（`.transition-item-move`）を完全維持
- 同名のみ `#0/#1…` で一意化。ドラッグは座標ベースの `:id` 依存で無影響

## 修正2: 性別トグルが効かない
入力テーブルの色判定 `getColorByName` が `studentsName.indexOf(name)` で性別を引いていたため、同名だと常に1人目を参照していた（`toggleGender` 自体は座標で `genderTable` を正しく更新）。
座席の性別を**座標から直接**引く `getColorBySeat(col, row)` を新設し、入力テーブルの色判定をこれに切り替え。
- 一意名のケースは従来と完全に同じ色（`genderArray[indexOf(name)] === genderTable[row][col]`）
- 結果テーブルは別座標を渡す設計のため `getColorByName` は維持

## 修正3: 同名・異性別で席替えエラー
`shuffleSeats()` が性別・元座席を `indexOf(name)` で引いていたため、同名だと常に1人目（男）の性別と判定され、女性の山田を女性席に置けず無限リスタート→エラーになっていた。
残った生徒に**元の並びから性別・元座席を1人ずつ消費して割り当てる**方式に変更（同名でも取り違えない）。一意名のケースは従来と同一挙動。

## 回帰テスト
- `tests/duplicate-name.spec.js`: キーの一意性、一意名キーの安定性、**同名2人で2人目をトグル→座席ごとに色が切り替わる（DOM検証）**
- `tests/duplicate-name-gender.spec.js`: 男女の山田で10回連続席替え→エラーなし・各席の性別保持・4人全員配置

各テストとも **修正前は失敗（再現）→ 修正後は合格** を確認済み。

## 検証
- `node --check` 構文OK
- Playwright **全40テスト合格**（一意名ケースの非劣化、等価性、ドラッグ/性別/異なる席を含む）

## スコープ（既知の制限）
同名の生徒に**個別条件**（前後固定／近づける・離す／固定座席／班長）を付けた場合は、条件側が名前で生徒を識別する設計上、どちらの同名生徒かを区別できないあいまいさが残ります。実運用で稀なケースのため本PRのスコープ外とします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)