### PR TITLE
同名・異性別の生徒で席替えがエラーになる問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -1697,9 +1697,24 @@
         },
         shuffleSeats() { // 条件のない生徒を席替え
           this.shuffle(this.dupSeatsTableIndex); // インデックスをシャッフル
-          this.dupStudentsName.forEach(dupStudentName => { // 生徒を一人取り出す
+          // 残った生徒に、元の並び（studentsName/genderArray/seatsTableIndex）から性別と元座席を割り当てる。
+          // 同名の生徒がいても元インデックスを1人ずつ消費するので、性別や元座席を取り違えない（例: 男の山田と女の山田）。
+          const usedOriginalIndex = new Set();
+          const remainingStudents = this.dupStudentsName.map(name => {
+            let originalIndex = -1;
+            for (let i = 0; i < this.studentsName.length; i++) {
+              if (!usedOriginalIndex.has(i) && this.studentsName[i] === name) {
+                usedOriginalIndex.add(i);
+                originalIndex = i;
+                break;
+              }
+            }
+            return { name, gender: this.genderArray[originalIndex], originalSeat: this.seatsTableIndex[originalIndex] };
+          });
+          remainingStudents.forEach(student => { // 生徒を一人取り出す
             let topIndex = this.dupSeatsTableIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
-            while ((this.isFixGender && !this.checkGender(dupStudentName, topIndex)) || (this.isAllDifferent && !this.checkDifferent(dupStudentName, topIndex))) { // 条件を満たさない間、繰り返す
+            // 性別固定: 座席の性別が生徒の性別と一致するか／異なる席: 元の座席と違うか。満たさない間、別の座席を試す
+            while ((this.isFixGender && this.genderTable[topIndex[1]][topIndex[0]] !== student.gender) || (this.isAllDifferent && student.originalSeat.toString() === topIndex.toString())) {
               if (this.calcNum > this.seatsNum) {
                 this.restartFlag = true;
                 break;
@@ -1708,10 +1723,8 @@
               topIndex = this.dupSeatsTableIndex.shift(); // 配列先頭のインデックスを再度取り出す
               this.calcNum += 1;
             }
-            this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, dupStudentName); // 取り出したインデックスの位置に生徒名を保存
-            const genderIndex = this.studentsName.indexOf(dupStudentName); // 生徒名に対応する性別のインデックスを取得
-            const gender = this.genderArray[genderIndex]; // 生徒名に対応する性別を取得
-            this.nextGenderTable[topIndex[1]].splice(topIndex[0], 1, gender);// 復元用のnextGenderTableに席替え後の性別を保存
+            this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, student.name); // 取り出したインデックスの位置に生徒名を保存
+            this.nextGenderTable[topIndex[1]].splice(topIndex[0], 1, student.gender); // 復元用のnextGenderTableに席替え後の性別を保存
           })
         },
         shuffle(array) { // 配列をランダムにシャッフル

--- a/tests/duplicate-name-gender.spec.js
+++ b/tests/duplicate-name-gender.spec.js
@@ -1,0 +1,48 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const INDEX_HTML = `file://${path.resolve(__dirname, '../index.html')}`;
+
+test.describe('同名・異性別の生徒（性別固定）', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(INDEX_HTML, { waitUntil: 'networkidle' });
+  });
+
+  test('男の山田と女の山田がいても席替えがエラーにならず、性別配置が保たれる', async ({ page }) => {
+    await page.evaluate(() => {
+      // 男2(山田/鈴木) 女2(佐藤/山田)。山田は男女1人ずつ
+      app.seatsTable.splice(0, 1, ['山田', '佐藤', '', '', '', '']);
+      app.seatsTable.splice(1, 1, ['山田', '鈴木', '', '', '', '']);
+      app.genderTable.splice(0, 1, ['male', 'female', '', '', '', '']);
+      app.genderTable.splice(1, 1, ['female', 'male', '', '', '', '']);
+      app.countSeats();
+    });
+    await page.waitForTimeout(150); // watcherでstudentsName/genderArray/seatsTableIndexが更新されるのを待つ
+
+    for (let i = 0; i < 10; i++) {
+      const result = await page.evaluate(() => {
+        app.error = false;
+        app.changeSeats();
+        // 配置された各座席で、生徒の性別が座席の性別(genderTable)と一致しているか
+        let genderOk = true;
+        const names = [];
+        for (let row = 0; row < 2; row++) {
+          for (let col = 0; col < 2; col++) {
+            const name = app.nextSeatsTable[row][col];
+            names.push(name);
+            // nextGenderTable(配置後の性別)が、元のgenderTable(座席固定の性別)と一致
+            if (app.nextGenderTable[row][col] !== app.genderTable[row][col]) genderOk = false;
+          }
+        }
+        names.sort();
+        return { error: app.error, genderOk, names };
+      });
+
+      expect(result.error).toBe(false);   // 修正前はtrue（無限リスタート→エラー）
+      expect(result.genderOk).toBe(true); // 各席の性別が保たれている
+      // 4人全員が配置されている（同名の山田2人を含む）
+      expect(result.names).toEqual(['佐藤', '山田', '山田', '鈴木'].sort());
+    }
+  });
+});


### PR DESCRIPTION
## 概要
**男の「山田」と女の「山田」**のように、同名で性別が異なる生徒がいると、席替え実行時にエラー（「条件を満たす席の配置が存在しません」）が出る問題を修正しました。

## 原因
`shuffleSeats()`（条件のない生徒を配置する処理）が、生徒の性別・元座席を `studentsName.indexOf(name)` で引いていました。同名の生徒がいると `indexOf` は常に**1人目**を返すため、2人目の「山田」も1人目（男）の性別と判定されます。

その結果、女性の「山田」を女性席に置けず（性別固定ON時）、配置が成立せず無限リスタート → 500回上限 → エラーになっていました。`checkGender` / `checkDifferent` / 性別の書き込みがいずれも名前引きだったことが根因です。

再現（master）:
```
studentsName = ["山田","佐藤","山田","鈴木"]
genderArray  = ["male","female","female","male"]
→ changeSeats() で app.error === true
```

## 変更内容
`shuffleSeats()` を、残った生徒に**元の並び（`studentsName`/`genderArray`/`seatsTableIndex`）から性別と元座席を1人ずつ消費して割り当てる**方式に変更：

```js
const usedOriginalIndex = new Set();
const remainingStudents = this.dupStudentsName.map(name => {
  let originalIndex = -1;
  for (let i = 0; i < this.studentsName.length; i++) {
    if (!usedOriginalIndex.has(i) && this.studentsName[i] === name) {
      usedOriginalIndex.add(i); originalIndex = i; break;
    }
  }
  return { name, gender: this.genderArray[originalIndex], originalSeat: this.seatsTableIndex[originalIndex] };
});
```
配置時の判定もこの per-student の性別・元座席で行います（`checkGender`/`checkDifferent` と論理的に等価）。

- **同名の生徒でも性別・元座席を取り違えない**（男の山田／女の山田を正しく振り分け）
- **一意な名前のケースは従来と完全に同一**の挙動（`indexOf` と同じ原インデックスに解決され、性別判定も等価）

## 回帰テスト（`tests/duplicate-name-gender.spec.js`）
男2（山田/鈴木）・女2（佐藤/山田）で10回連続席替えし、
- `app.error === false`（エラーにならない）
- 各席の性別（`nextGenderTable` == `genderTable`）が保たれる
- 山田2人を含む4人全員が配置される

を検証。**修正前は失敗（エラー再現）→ 修正後は合格**を確認済み。

## 検証
- `node --check` 構文OK
- Playwright 全37テスト合格（既存36 + 新規1）。一意名ケースの非劣化を確認。

## スコープ（補足）
本修正は条件のない生徒を配置する `shuffleSeats()` を対象とし、ユーザー報告のケース（山田に個別条件なし）を完全に解消します。同名の生徒に**さらに前後固定・近づける/離す・班長などの個別条件**を付けた場合は、条件側が名前ベースで生徒を識別する設計上の曖昧さが残ります（別途対応が必要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)