### PR TITLE
今の座席カードに「一括入力」ボタンを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -1002,15 +1002,24 @@
           :class="{'left-card-margin-large': seatsSizeX<8, 'left-card-margin-small': seatsSizeX>=8}"
           data-intro="座席に生徒名を入力します。<br>Tabキーを押すと右の座席に移動できます。<br>座席をクリックすると性別を切り替えることができます。" data-title="2. 名前を入力！"
           data-position="right" data-step="2">
-          <v-card-title class="justify-center text-h4" style="font-weight: 900; margin-left: 25px;">今の座席
-            <v-tooltip top>
-              <template v-slot:activator="{ on, attrs }">
-                <v-icon color="#005b69" style="margin-left: 5px; padding-bottom: 10px;" v-bind="attrs"
-                  v-on="on">mdi-information-outline</v-icon>
-              </template>
-              <div>クリックで性別を切り替えることができます</div>
-              <div>Tabキーを押すと次の座席に移動することができます</div>
-            </v-tooltip>
+          <v-card-title class="justify-center text-h4" style="font-weight: 900; margin-left: 25px;">
+            <!-- 「今の座席」＋情報アイコンを中央寄せの基準にし、ボタンは絶対配置で右にぶら下げる
+                 （ボタンは通常フローの外なので、文字の幅・中央寄せに一切影響しない） -->
+            <span style="position: relative; display: inline-flex; align-items: center; white-space: nowrap;">今の座席
+              <v-tooltip top>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-icon color="#005b69" style="margin-left: 5px; padding-bottom: 10px;" v-bind="attrs"
+                    v-on="on">mdi-information-outline</v-icon>
+                </template>
+                <div>クリックで性別を切り替えることができます</div>
+                <div>Tabキーを押すと次の座席に移動することができます</div>
+              </v-tooltip>
+              <!-- 一括入力ボタン（文字のすぐ右に絶対配置） -->
+              <v-btn elevation="2" height="40" color="white"
+                @click="isShowStudentsNameDialog = true;"
+                style="position: absolute; left: 100%; top: 50%; transform: translateY(-50%); margin-left: 14px; font-size: 1.5rem; line-height: 1; font-weight: 900; text-transform: none; color: #0c9ea8;">一括入力
+              </v-btn>
+            </span>
           </v-card-title>
           <div class="seats-scroll-container">
             <li v-for="( seats, indexRow ) in seatsTable" style="margin-left: -4px;">


### PR DESCRIPTION
## 概要

名簿のコピペ一括入力機能をより目立たせるため、「今の座席」カードのタイトル右側に「一括入力」ボタンを追加しました。クリックすると既存の「名前を一括入力」ダイアログ（`isShowStudentsNameDialog`）が開きます。

## 変更点

- 「今の座席」タイトル行の右に白背景＋ティール文字の「一括入力」ボタンを配置
- タイトルテキストとボタンを `<span>` でまとめ、ボタンは **絶対配置（position: absolute）** で右にぶら下げる方式に変更
  - ボタンが通常フローの外に出るため、「今の座席」の**中央寄せ・カード高さに影響しない**
- 既存のロジックは再利用（`@click="isShowStudentsNameDialog = true"`）、新規ロジックの追加なし

## 確認したこと

- ✅ 「今の座席」は中央維持、「席替え後」とカード高さ一致
- ✅ クリックで一括入力ダイアログが開く
- ✅ レスポンシブ確認：PC（1440〜1905px）・タブレット（601〜1439px）の各幅でボタンがカード内に収まり、タイトルは1行・中央を維持
- ✅ 既存テスト（座席条件ロジック）はタイトル/ボタンのセレクタに非依存のため影響なし
- ✅ コンソールエラーなし

## 補足（任意）

- サイドバーの既存ボタンは「コピペで入力」、本ボタンは「一括入力」と表記が異なります（ダイアログ名「名前を一括入力」に合わせています）。統一が望ましければ別途調整可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)