### PR TITLE
保存・復元まわりの表示不具合を修正（性別色の消失／空席の色残り）

### DIFF
--- a/index.html
+++ b/index.html
@@ -1390,7 +1390,6 @@
         restartFlag: false, // 条件を満たしていないとき、changeSeats()の最初からリスタートする制御用フラグ
         genderTable: [], // 生徒の性別テーブル、性別が入る二次元配列
         genderArray: [], // 生徒の性別配列、テーブルを展開したもの、studentsName[]と順番が対応
-        nextGenderTable: [], // 席替え後の生徒の性別テーブル、性別が入る二次元配列
         isAllDifferent: true, // 前回の座席と異なる配置にするかどうかの制御フラグ
         isFixGender: true, // 性別を固定するかどうかの制御フラグ
         fixConditions: [['', '', '']], // 近づける条件配列
@@ -1625,17 +1624,18 @@
             return 'off-seats'
           }
         },
-        getColorByNextSeat(name, col, row) { // 席替え後（結果テーブル）の座席色を返す
-          let gender;
+        genderAtNextSeat(name, col, row) { // 席替え後（結果テーブル）の座席(col,row)に座る生徒の性別を返す。色表示と保存で共通利用する単一の判定ロジック
           if (this.isFixGender) {
             // 性別固定中は「その席に座る生徒の性別＝その席に設定された性別」なので座標から判定する。
             // これなら同名の生徒（例: 男の山田と女の山田）でも席ごとに正しい色になる。
-            gender = this.genderTable[row][col];
-          } else {
-            // 性別固定OFF時は座席で性別が決まらないため、生徒の性別を名前から引く（同名は1人目基準）。
-            const genderIndex = this.studentsName.indexOf(name);
-            gender = genderIndex === -1 ? '' : this.genderArray[genderIndex];
+            return this.genderTable[row][col];
           }
+          // 性別固定OFF時は座席で性別が決まらないため、生徒の性別を名前から引く（同名は1人目基準）。
+          const genderIndex = this.studentsName.indexOf(name);
+          return genderIndex === -1 ? '' : this.genderArray[genderIndex];
+        },
+        getColorByNextSeat(name, col, row) { // 席替え後（結果テーブル）の座席色を返す
+          const gender = this.genderAtNextSeat(name, col, row);
           if (gender === 'male') {
             return 'male-seats'
           } else if (gender === 'female') {
@@ -1784,7 +1784,6 @@
               this.calcNum += 1;
             }
             this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, student.name); // 取り出したインデックスの位置に生徒名を保存
-            this.nextGenderTable[topIndex[1]].splice(topIndex[0], 1, student.gender); // 復元用のnextGenderTableに席替え後の性別を保存
           })
         },
         shuffle(array) { // 配列をランダムにシャッフル
@@ -2109,9 +2108,6 @@
             if (this.restartFlag) return;
 
             this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, leaderName); // 取り出したインデックスの位置に班長名を保存
-            const genderIndex = this.studentsName.indexOf(leaderName);
-            const gender = this.genderArray[genderIndex];
-            this.nextGenderTable[topIndex[1]].splice(topIndex[0], 1, gender); // 復元用のnextGenderTableに席替え後の性別を保存
 
             // ここで配置した班長は他の配置処理で配置する必要がないため、各配列から削除する
             this.removeFromArray(topIndex, this.dupSeatsTableIndex);
@@ -2215,12 +2211,6 @@
             }
           }
         },
-        makeNextGenderTable() { // nextGenderTableを作成
-          this.nextGenderTable = []
-          for (let i = 0; i < this.seatsSizeY; i++) {
-            this.nextGenderTable.push(Array(this.seatsSizeX).fill('')) // すべての席に性別が未入力な状態でテーブルを作成
-          }
-        },
         removeFromArray(target, array) {
           const deleteIndex = looseIndexOf(array, target); // 削除したいtargetがある配列arrayのインデックスを取得
           if (deleteIndex !== -1) { // targetが配列arrayになければ返り値が-1となるので、そのときは削除しない
@@ -2320,9 +2310,14 @@
             id = String(Date.now());
           }
 
+          // 結果テーブルの各席の性別を表示と同じロジックで組み立てる。
+          // 固定/前後列/近づける/離す等で配置された生徒の性別も漏れなく保存できる
+          const savedGenderTable = this.nextSeatsTable.map((seatsRow, row) =>
+            seatsRow.map((name, col) => name === '' ? '' : this.genderAtNextSeat(name, col, row))
+          );
           const data = {
             seatsTable: this.nextSeatsTable,
-            genderTable: this.nextGenderTable,
+            genderTable: savedGenderTable,
             seatsSizeX: this.seatsSizeX,
             seatsSizeY: this.seatsSizeY,
             groupSizeX: this.groupSizeX,
@@ -2366,7 +2361,6 @@
           this.isFixGender = true;
           this.countSeats();
           this.makeNextSeatsTable();
-          this.makeNextGenderTable();
           this.isShowRestoreDialog = false;
         },
         deleteSavedData(id, name) { // 保存データを削除する
@@ -2393,7 +2387,6 @@
         this.makeSeatsTable(); // 最初にseatsTableを作成
         this.makeNextSeatsTable(); // 席替え後用のnextSeatsTableを空白で作成
         this.makeGenderTable(); // genderTableを作成
-        this.makeNextGenderTable(); // 席替え後用のnextGenderTableを作成
         this.setSidebarWidth();
         if (window.innerWidth < BREAKPOINT_PC) { // SP・TBのとき
           this.drawer = false; // 初期はサイドバーを非表示
@@ -2468,7 +2461,6 @@
             this.remakeSeatsTable(); // 現在の座席テーブルを新しい大きさで作り直す
             this.makeNextSeatsTable() // 次の座席テーブルを新しい大きさで作り直す
             this.remakeGenderTable() // 性別テーブルを新しい大きさで作り直す
-            this.makeNextGenderTable() // 次の性別テーブルを新しい大きさで作り直す
             switch (this.seatsSizeX) { // 班の大きさとデフォルト値を変更する
               case 1:
                 this.groupSizeOptionsX = ['なし'];
@@ -2532,7 +2524,6 @@
             this.remakeSeatsTable(); // 現在の座席テーブルを新しい大きさで作り直す
             this.makeNextSeatsTable() // 次の座席テーブルを新しい大きさで作り直す
             this.remakeGenderTable() // 性別テーブルを新しい大きさで作り直す
-            this.makeNextGenderTable() // 次の性別テーブルを新しい大きさで作り直す
             switch (this.seatsSizeY) { // 班の大きさとデフォルト値を変更する
               case 1:
                 this.groupSizeOptionsY = ['なし'];

--- a/index.html
+++ b/index.html
@@ -1624,7 +1624,8 @@
             return 'off-seats'
           }
         },
-        genderAtNextSeat(name, col, row) { // 席替え後（結果テーブル）の座席(col,row)に座る生徒の性別を返す。色表示と保存で共通利用する単一の判定ロジック
+        genderAtNextSeat(name, col, row) { // 席替え後（結果テーブル）の座席(col,row)に座る生徒の性別を返す。空席（生徒なし）は''。色表示と保存で共通利用する単一の判定ロジック
+          if (name === '') return ''; // 空席は性別なし。結果テーブルが空のとき（復元直後や席替え前）に色だけ残るのを防ぐ
           if (this.isFixGender) {
             // 性別固定中は「その席に座る生徒の性別＝その席に設定された性別」なので座標から判定する。
             // これなら同名の生徒（例: 男の山田と女の山田）でも席ごとに正しい色になる。
@@ -2313,7 +2314,7 @@
           // 結果テーブルの各席の性別を表示と同じロジックで組み立てる。
           // 固定/前後列/近づける/離す等で配置された生徒の性別も漏れなく保存できる
           const savedGenderTable = this.nextSeatsTable.map((seatsRow, row) =>
-            seatsRow.map((name, col) => name === '' ? '' : this.genderAtNextSeat(name, col, row))
+            seatsRow.map((name, col) => this.genderAtNextSeat(name, col, row))
           );
           const data = {
             seatsTable: this.nextSeatsTable,

--- a/tests/duplicate-name-gender.spec.js
+++ b/tests/duplicate-name-gender.spec.js
@@ -24,23 +24,31 @@ test.describe('同名・異性別の生徒（性別固定）', () => {
       const result = await page.evaluate(() => {
         app.error = false;
         app.changeSeats();
-        // 配置された各座席で、生徒の性別が座席の性別(genderTable)と一致しているか
-        let genderOk = true;
+        // 男性席・女性席それぞれに配置された生徒名を集める。
+        // 同名(山田)が男女に1人ずついるためname→性別マップは作れないが、
+        // 「男性席に座る生徒の集合 == 男性の生徒の集合」を検証すれば誤配置を確実に検出できる。
+        const maleSeatNames = [];
+        const femaleSeatNames = [];
         const names = [];
         for (let row = 0; row < 2; row++) {
           for (let col = 0; col < 2; col++) {
             const name = app.nextSeatsTable[row][col];
+            if (name === '') continue;
             names.push(name);
-            // nextGenderTable(配置後の性別)が、元のgenderTable(座席固定の性別)と一致
-            if (app.nextGenderTable[row][col] !== app.genderTable[row][col]) genderOk = false;
+            if (app.genderTable[row][col] === 'male') maleSeatNames.push(name);
+            else if (app.genderTable[row][col] === 'female') femaleSeatNames.push(name);
           }
         }
         names.sort();
-        return { error: app.error, genderOk, names };
+        maleSeatNames.sort();
+        femaleSeatNames.sort();
+        return { error: app.error, maleSeatNames, femaleSeatNames, names };
       });
 
-      expect(result.error).toBe(false);   // 修正前はtrue（無限リスタート→エラー）
-      expect(result.genderOk).toBe(true); // 各席の性別が保たれている
+      expect(result.error).toBe(false); // 修正前はtrue（無限リスタート→エラー）
+      // 男性席には男性の生徒(山田・鈴木)、女性席には女性の生徒(佐藤・山田)だけが座る
+      expect(result.maleSeatNames).toEqual(['山田', '鈴木'].sort());
+      expect(result.femaleSeatNames).toEqual(['佐藤', '山田'].sort());
       // 4人全員が配置されている（同名の山田2人を含む）
       expect(result.names).toEqual(['佐藤', '山田', '山田', '鈴木'].sort());
     }

--- a/tests/gender-condition.spec.js
+++ b/tests/gender-condition.spec.js
@@ -10,10 +10,22 @@ async function setupDemoData(page) {
 
 async function runChangeSeats(page) {
   return await page.evaluate(() => {
+    // 席替え前に「生徒名→本来の性別」を入力テーブルから記録する（genderTableはchangeSeatsで変化しない）
+    const studentGenderMap = {};
+    for (let row = 0; row < app.seatsTable.length; row++) {
+      for (let col = 0; col < app.seatsTable[row].length; col++) {
+        const name = app.seatsTable[row][col];
+        if (name) studentGenderMap[name] = app.genderTable[row][col];
+      }
+    }
     app.changeSeats();
     return {
       nextSeatsTable: app.nextSeatsTable,
-      nextGenderTable: app.nextGenderTable,
+      // 結果の各席に「実際に配置された生徒の本来の性別」を割り当てる。
+      // 席の固定性別(genderTable)ではなく生徒由来の値なので、誤配置があれば検出できる
+      placedGenderTable: app.nextSeatsTable.map(rowArr =>
+        rowArr.map(name => name === '' ? '' : studentGenderMap[name])
+      ),
     };
   });
 }
@@ -34,10 +46,11 @@ test.describe('性別の並びを固定（isFixGender）', () => {
     await page.waitForTimeout(50);
 
     for (let i = 0; i < 10; i++) {
-      const { nextGenderTable } = await runChangeSeats(page);
+      // 各席に配置された生徒の本来の性別が、その席に固定された性別と一致していることを検証する
+      const { placedGenderTable } = await runChangeSeats(page);
       for (let row = 0; row < originalGenderTable.length; row++) {
         for (let col = 0; col < originalGenderTable[row].length; col++) {
-          expect(nextGenderTable[row][col]).toBe(originalGenderTable[row][col]);
+          expect(placedGenderTable[row][col]).toBe(originalGenderTable[row][col]);
         }
       }
     }

--- a/tests/save-restore.spec.js
+++ b/tests/save-restore.spec.js
@@ -51,4 +51,35 @@ test.describe('保存・復元', () => {
 
     expect(missingGender).toBe(0); // 旧実装ではA・Bの2席が''になり 2 になる
   });
+
+  test('復元直後、空の「席替え後」テーブルの各席は無色（off-seats）で表示される', async ({ page }) => {
+    // restoreByNameはnextSeatsTableを空にするが、getColorByNextSeatが空席にも
+    // genderTableの色を付けていたため、「名前なし＋色つき」のセルが残っていた。
+    const coloredEmptySeats = await page.evaluate(() => {
+      app.seatsTable.splice(0, 1, ['A', 'B', '', '', '', '']);
+      app.genderTable.splice(0, 1, ['male', 'female', '', '', '', '']);
+      app.countSeats();
+      app.isFixGender = true;
+      app.changeSeats();
+
+      app.saveName = 'テスト保存';
+      app.saveWithName(true);
+      const list = app.getSavedList();
+      app.restoreByName(list[0].id); // nextSeatsTableは空になる
+
+      // 空の結果テーブルの全席が off-seats（無色）であること
+      let colored = 0;
+      for (let row = 0; row < app.seatsSizeY; row++) {
+        for (let col = 0; col < app.seatsSizeX; col++) {
+          const name = app.nextSeatsTable[row][col];
+          if (name === '' && app.getColorByNextSeat(name, col, row) !== 'off-seats') {
+            colored += 1;
+          }
+        }
+      }
+      return colored;
+    });
+
+    expect(coloredEmptySeats).toBe(0); // 旧実装では色が残り 0 より大きくなる
+  });
 });

--- a/tests/save-restore.spec.js
+++ b/tests/save-restore.spec.js
@@ -1,0 +1,54 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const INDEX_HTML = `file://${path.resolve(__dirname, '../index.html')}`;
+
+test.describe('保存・復元', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(INDEX_HTML, { waitUntil: 'networkidle' });
+    await page.evaluate(() => { localStorage.clear(); });
+  });
+
+  test('「近づける」条件で配置した生徒の性別が、保存→復元後も失われない', async ({ page }) => {
+    // 「近づける」はchangeNearFarSeats経由で配置される。この経路はshuffleSeats/placeLeaders
+    // と違い性別を記録していなかったため、旧実装では保存→復元で席の色が消えていた。
+    // 班長(placeLeaders)経由で配置されないよう、leaderConditionsは空のままにする。
+    const result = await page.evaluate(() => {
+      app.seatsTable.splice(0, 1, ['A', 'B', '', '', '', '']);
+      app.seatsTable.splice(1, 1, ['C', 'D', '', '', '', '']);
+      app.genderTable.splice(0, 1, ['male', 'female', '', '', '', '']);
+      app.genderTable.splice(1, 1, ['female', 'male', '', '', '', '']);
+      app.countSeats();
+      return null;
+    });
+    await page.waitForTimeout(150); // watcherでstudentsName/genderArray/seatsTableIndexが更新されるのを待つ
+
+    const missingGender = await page.evaluate(() => {
+      app.isFixGender = true;
+      app.nearConditions = [['A', 'B', 0], ['', '', '']]; // AとBを近づける
+      app.changeSeats();
+
+      // 保存
+      app.saveName = 'テスト保存';
+      app.saveWithName(true);
+
+      // 一覧から復元
+      const list = app.getSavedList();
+      app.restoreByName(list[0].id);
+
+      // 復元後、生徒がいる席はすべて性別が設定されている（''がない）はず
+      let missing = 0;
+      for (let row = 0; row < app.seatsSizeY; row++) {
+        for (let col = 0; col < app.seatsSizeX; col++) {
+          if (app.seatsTable[row][col] !== '' && app.genderTable[row][col] === '') {
+            missing += 1;
+          }
+        }
+      }
+      return missing;
+    });
+
+    expect(missingGender).toBe(0); // 旧実装ではA・Bの2席が''になり 2 になる
+  });
+});


### PR DESCRIPTION
保存・復元機能の表示まわりにあった2つの不具合を修正します。どちらも `master` から存在する既存バグです。

---

## ① 条件配置した生徒の性別色が失われる

### 概要
**固定／最前列／前2列／最後列／後ろ2列／近づける／離す** の条件で配置した生徒の性別色が、保存→復元すると失われ「今の座席」で灰色になる。

### 原因
`saveWithName` は `nextGenderTable` を保存していたが、`nextGenderTable` への書き込みは `shuffleSeats` と `placeLeaders` の2経路だけ。上記条件で配置された生徒の性別は記録されず空のままだった。

### 修正
- 結果テーブルの性別判定を **`genderAtNextSeat()`** に集約し、色表示（`getColorByNextSeat`）と保存で同一ロジックを共有
- 保存時に結果テーブル（`nextSeatsTable`）から性別テーブルを組み立て、配置経路に依存せず漏れなく保存
- 部分的にしか維持できていなかった `nextGenderTable` の状態管理を全削除（クリーンアップ）

---

## ② 復元後、「席替え後」の空席に色だけ残る

### 概要
復元すると保存した座席は「今の座席」に正しく読み込まれる（名前は失われない）が、クリアされた「席替え後」パネルの空席に色だけが残り、「名前なし＋色つき」のセルになって、あたかも名前が消えたように見える。

### 原因
`restoreByName` は `nextSeatsTable` を空にするが、`getColorByNextSeat` が空席でも `genderTable` を参照して色を返していた。

### 修正
- `genderAtNextSeat` に空席ガードを追加（生徒のいない席は性別なし `''`）→ 空席は無色（`off-seats`）に
- `saveWithName` のマップを空席判定込みで `genderAtNextSeat` に集約し簡潔化

なお復元先は従来どおり「今の座席」のままとしています。

---

## テスト・検証

- **保存・復元の回帰テストを新規追加**（`tests/save-restore.spec.js`）。従来この経路はノーカバレッジでした。
  - ①: 「近づける」条件（`changeNearFarSeats` 経由＝旧実装が性別を記録しない経路）で配置した生徒の性別が復元後も保持されること
  - ②: 復元直後の空「席替え後」テーブルの各席が無色（`off-seats`）であること
- 既存の性別テスト2件を、席の固定性別ではなく**実際に配置された生徒の本来の性別**で検証する形に修正（恒真化を回避）。性別チェックを一時的に無効化するとテストが失敗することを確認し、誤配置を実際に検出できることを担保。
- ①のバグ再現確認: 修正前コードで回帰テストが失敗 → 修正後は成功することを確認。
- ②の確認: ブラウザ（Playwright）で復元後の「席替え後」が白い空セルになることを確認。
- **全43テストがパス**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)