### PR TITLE
未使用のlodashの読み込みを削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -1321,7 +1321,6 @@
   <script src="https://cdn.jsdelivr.net/npm/vue@2.7.16/dist/vue.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/vuetify@2.7.2/dist/vuetify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.14.1/lodash.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/intro.js@3.3.1/intro.min.js"></script>
 
   <script>


### PR DESCRIPTION
## 概要
CDNから読み込んでいる lodash 4.14.1 を削除します。

## 背景
- コード中に `_.` の使用箇所が **0件** で、完全に未使用
- 毎回約25KB(gzip)の無駄な転送が発生していた
- lodash 4.14.1 は2016年リリースで、プロトタイプ汚染(CVE-2018-3721, CVE-2019-10744)、`_.template` のコマンドインジェクション(CVE-2021-23337)等の既知脆弱性を複数含む

未使用のため実害はありませんでしたが、削除により転送量・攻撃面の両方が解消されます。

## 変更内容
- `<script>` タグ1行の削除のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)