### PR TITLE
セキュリティヘッダーがトップページに適用されない問題を修正

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,25 @@
 [build]
   publish = "."
 
+# セキュリティヘッダーは全パスに適用する
+# ("/*.html" だとトップページのパス "/" にマッチせず、ヘッダーが付与されない)
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "DENY"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+
+# トップページはパス "/" で配信されるため、"/*.html" とは別に指定が必要
+[[headers]]
+  for = "/"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
 [[headers]]
   for = "/*.html"
   [headers.values]
     Cache-Control = "public, max-age=0, must-revalidate"
-    X-Content-Type-Options = "nosniff"
-    X-Frame-Options = "DENY"
-    Referrer-Policy = "strict-origin-when-cross-origin"
 
 [[headers]]
   for = "/*.js"


### PR DESCRIPTION
## 概要
`netlify.toml` のヘッダールール `for = "/*.html"` を修正し、セキュリティヘッダーがトップページに付与されるようにします。

## 問題
Netlifyのヘッダールールは**リクエストパス**に対して適用されるため、`/*.html` というパターンはユーザーが実際にアクセスする `https://sekigae.jp/`(パス `/`)にマッチしません。

実際に本番で確認した結果、トップページには X-Frame-Options / X-Content-Type-Options / Referrer-Policy が**一切付与されていません**でした:

```
$ curl -sI https://sekigae.jp/ | grep -i 'x-frame\|x-content\|referrer'
(出力なし)
```

## 変更内容
- セキュリティヘッダー3種を `for = "/*"`(全パス)に移動
- `Cache-Control: max-age=0` は `/` と `/*.html` に個別指定
  - `/*` に含めると `/*.png` 等の immutable ルールと同一ヘッダーが重複適用されてしまうため分離しています

## 確認方法
デプロイ後に以下で3ヘッダーが付与されることを確認できます:
```
curl -sI https://sekigae.jp/ | grep -i 'x-frame\|x-content\|referrer\|cache-control'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)