### PR TITLE
「今の座席」の:keyが行列の組み合わせで衝突しうる問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -1051,20 +1051,20 @@
                 <input type="text" v-if="indexRow==0 && indexCol==0"
                   :class="['seat', getColorBySeat(indexCol, indexRow)]"
                   @input="writeStudentName( indexCol, indexRow, $event.target.value ); countSeats();"
-                  :key="indexRow.toString() + indexCol.toString()"
+                  :key="indexRow + '-' + indexCol"
                   style="text-align: center;  resize: none; word-break: keep-all; vertical-align: top; font-size: 22px; font-weight: 600;"
                   :value="seatsTable[indexRow][indexCol]" @click="toggleGender(indexCol,indexRow)" placeholder="安藤">
                 <!-- 2つ目のフォームにプレイスホルダーを設定 -->
                 <input type="text" v-else-if="indexRow==0 && indexCol==1"
                   :class="['seat', getColorBySeat(indexCol, indexRow)]"
                   @input="writeStudentName( indexCol, indexRow, $event.target.value ); countSeats();"
-                  :key="indexRow.toString() + indexCol.toString()"
+                  :key="indexRow + '-' + indexCol"
                   style="text-align: center;  resize: none; word-break: keep-all; vertical-align: top; font-size: 22px; font-weight: 600;"
                   :value="seatsTable[indexRow][indexCol]" @click="toggleGender(indexCol,indexRow)" placeholder="石原">
                 <!-- 3つ目以降のフォーム -->
                 <input type="text" v-else :class="['seat', getColorBySeat(indexCol, indexRow)]"
                   @input="writeStudentName( indexCol, indexRow, $event.target.value ); countSeats();"
-                  :key="indexRow.toString() + indexCol.toString()"
+                  :key="indexRow + '-' + indexCol"
                   style="text-align: center;  resize: none; word-break: keep-all; vertical-align: top; font-size: 22px; font-weight: 600;"
                   :value="seatsTable[indexRow][indexCol]" @click="toggleGender(indexCol,indexRow)">
                 <span :class="{'margin-right': (indexCol+1)%groupSizeX==0 && (indexCol+1)!=seatsSizeX}"></span>


### PR DESCRIPTION
## 概要
「今の座席」テーブルの `:key` を衝突しない形式に修正します。

## 問題
`:key="indexRow.toString() + indexCol.toString()"` は単純な文字列連結のため、異なる座席が同じキーになるケースがあります:

| row | col | key |
|---|---|---|
| 1 | 11 | `"111"` |
| 11 | 1 | `"111"` |

2026.03.22 に座席数が最大12×12へ拡張されたため、2桁の行・列番号が現実に発生します。Vueは重複キーのある要素の再利用を保証できず、行・列サイズ変更時に入力値や性別色の表示が別の座席に紐付くなどの潜在的な描画不整合の原因になります。

なお「席替え後」テーブル側は `uniqueKey()` で対処済みで、入力側だけが未対応でした。

## 変更内容
- `:key="indexRow + '-' + indexCol"` に変更(3箇所)
  - `1-11` と `11-1` が区別されるようになります

## テスト
- `npx playwright test` : **43 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)