### PR TITLE
CIのNodeをEOL済みの20から22(LTS)に更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## 概要
GitHub Actions で使用する Node.js を 20 → 22 に更新します。

## 背景
- Node 20 は **2026年4月で EOL** となり、セキュリティ修正が提供されなくなっています
- Node 22 は現行の LTS です

## 変更内容
- `.github/workflows/test.yml` の `node-version: 20` → `22`
- 依存は `@playwright/test` のみのため、影響はテスト実行環境に限定されます(このPR自体のCIが通ることで動作確認になります)

🤖 Generated with [Claude Code](https://claude.com/claude-code)