### PR TITLE
スマホ時のサイドメニュー内の要素をコンパクトに調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,6 +288,9 @@
         display: grid;
         grid-template-columns: max-content 1fr;
         align-items: center;
+        /* 1行目のボタンのNEWバッジが領域上端からはみ出し、
+           背後を流れるコンテンツに重なるのを防ぐためののりしろ */
+        padding-top: 6px;
       }
 
       .sidebar-bottom-sticky .open-btn {

--- a/index.html
+++ b/index.html
@@ -226,11 +226,86 @@
         font-size: 34px !important;
       }
 
-      /* 下部固定領域が画面を占有しすぎないよう、ボタンをコンパクトにして間隔を空ける */
+      /* 使い方・デモデータボタンを縮小する（インラインstyleに勝つため!important）。
+         マイナスマージンはPC用の大きいタイトルに合わせた値のため、縮小後の高さに合わせて調整する */
+      .v-navigation-drawer .sidebar-top-btn {
+        height: 36px !important;
+        font-size: 14px !important;
+        margin: -10px 0 0 8px !important;
+        padding: 0 12px !important;
+      }
+
+      .v-navigation-drawer .sidebar-top-btn .v-icon {
+        font-size: 20px !important;
+      }
+
+      /* 条件パネルの見出しをコンパクトにする */
+      .v-navigation-drawer .v-expansion-panel-header {
+        font-size: 14px;
+        min-height: 42px;
+        padding: 10px 16px;
+      }
+
+      /* サイドバー内のセレクトボックスをVuetifyのdense相当（高さ40px）に縮小する */
+      .v-navigation-drawer .v-text-field--enclosed .v-input__slot {
+        min-height: 40px !important;
+      }
+
+      /* ドロップダウン矢印の縦位置を縮小後の高さの中央に合わせる */
+      .v-navigation-drawer .v-text-field--enclosed .v-input__append-inner {
+        margin-top: 8px !important;
+      }
+
+      /* 未選択時のラベル（横・縦）を縮小後の高さの中央に合わせる */
+      .v-navigation-drawer .v-text-field--outlined .v-label {
+        top: 10px;
+      }
+
+      /* 選択済みで枠上に浮いたラベルの位置も縮小後の高さに合わせる */
+      .v-navigation-drawer .v-text-field--outlined .v-label--active {
+        transform: translateY(-16px) scale(.75);
+      }
+
+      .v-navigation-drawer .v-select__selections {
+        font-size: 14px;
+      }
+
+      /* 下部固定領域が画面を占有しすぎないよう、ボタンをコンパクトにして間隔を空ける。
+         justify-self: startは、グリッド配置でボタンがセル幅いっぱいに引き伸ばされるのを防ぐ */
       .sidebar-bottom-sticky .v-btn {
         height: 44px !important;
-        font-size: 16px !important;
+        font-size: 14px !important;
         margin: 4px 8px 4px 0 !important;
+        padding: 0 12px !important;
+        justify-self: start;
+      }
+
+      /* 1列目:コピペで入力・結果を復元 / 2列目:席替え の並びにする。
+         DOM順は席替えが先頭のため、グリッドの明示配置で席替えだけ2行目に送る。
+         2列目を1frにするのは、全幅スパンするリンク行の内容幅が
+         max-content列に分配されてグリッド全体がはみ出すのを防ぐため */
+      .sidebar-bottom-sticky {
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        align-items: center;
+      }
+
+      .sidebar-bottom-sticky .open-btn {
+        grid-row: 2;
+        grid-column: 1 / -1;
+      }
+
+      /* 利用規約などのリンク行は全幅で最下段に置く。
+         padding-leftは折り返した行（フィードバック等）の左端も利用規約と揃えるための共通余白 */
+      .sidebar-bottom-sticky > div {
+        grid-column: 1 / -1;
+        min-width: 0;
+        padding-left: 10px;
+      }
+
+      /* 利用規約のインラインmargin-leftを打ち消す（左余白は上のpadding-leftで共通化） */
+      .sidebar-bottom-sticky > div a {
+        margin-left: 0 !important;
       }
 
       /* 全体・班の2カラムだと折り返して崩れるため、縦に積む
@@ -664,12 +739,13 @@
                   <h2 style="font-size: 40px; color: #555555; display: inline-block;" class="condition-title"><v-icon
                       color="#0c9ea8" style="font-size: 52px;">mdi-file-document-box-plus-outline</v-icon>条件</h2>
                   <!-- 使い方ボタン -->
-                  <v-btn elevation="2" large color="#0c9ea8" class="tutorial-btn" dark @click="startTutorial();"
+                  <v-btn elevation="2" large color="#0c9ea8" class="tutorial-btn sidebar-top-btn" dark
+                    @click="startTutorial();"
                     style="font-size: 20px; font-weight: 900; margin: -20px 0 0 20px; padding-right: 15px;">
                     <v-icon class="icon" style="padding-top: 4px;">mdi-magnify</v-icon>使い方
                   </v-btn>
                   <!-- デモデータのセットボタン -->
-                  <v-btn elevation="2" large color="#0c9ea8" class="demo-btn" dark
+                  <v-btn elevation="2" large color="#0c9ea8" class="demo-btn sidebar-top-btn" dark
                     @click="setDemoData(); hideSidebarOnlyTB();"
                     style="font-size: 20px; font-weight: 900; margin: -20px 0 0 10px; padding-right: 15px;">
                     <v-icon class="icon">mdi-pencil</v-icon>デモデータ


### PR DESCRIPTION
## 概要
スマホ（600px以下）のとき、サイドメニュー内のボタン・見出し・セレクトボックスが大きく表示が窮屈だったため、スマホ時のみコンパクトに調整しました。

## 変更内容（すべて `@media (max-width:600px)` 内のみ）
- **使い方・デモデータボタン**: 高さ44px→36px、フォント20px→14pxに縮小
- **条件パネルの見出し**（座席数を指定する 等）: 高さ48px→42px、フォント14pxに縮小
- **セレクトボックス**: Vuetifyの`dense`相当（高さ56px→40px、フォント14px）に縮小。矢印・ラベルの縦位置も縮小後の高さに合わせて調整
- **下部固定ボタン**: グリッド配置で「1列目: コピペで入力・結果を復元 / 2列目: 席替え」の2段組に変更（DOM順は変えず、CSSのみで並べ替え）
- **リンク行**: 折り返した2行目の先頭（フィードバック）の左端が利用規約と揃うように、利用規約個別のmargin-leftを行全体のpadding-leftに統一

メディアクエリ外の変更は、使い方・デモデータボタンへの`sidebar-top-btn`クラス追加のみ（スタイル定義はメディアクエリ内にしか存在しないため601px以上には無影響）。

## 動作確認（Playwrightで実測）
- ✅ スマホ 375px: 各要素の縮小・2段組レイアウト・リンク左端揃え（利用規約/フィードバックともleft=38px）を確認
- ✅ スマホ 320px（最小クラス）: ボタンのはみ出しなしを実測で確認
- ✅ セレクトボックスの開閉・値選択・フォーカス表示が正常に動作
- ✅ デグレ確認: 601px（境界）・800px（タブレット縦）・1100px（タブレット横）・1440px（PC）で元の見た目・サイズのままであることを実測とスクリーンショットで確認
- ✅ 追加CSSが全てスマホ用メディアクエリブロック内に閉じていることを機械的に検証（括弧バランス・セレクタ位置）

🤖 Generated with [Claude Code](https://claude.com/claude-code)