### PR TITLE
スマホ時に条件見出しと使い方・デモデータボタンを1行に収める

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,27 +216,31 @@
         padding-bottom: 14px;
       }
 
-      /* サイドバーの「条件」見出しを縮小し、使い方・デモデータと1行に収まりやすくする */
+      /* サイドバーの「条件」見出しを縮小し、使い方・デモデータと1行に収める */
       .grid-layout .condition-title {
-        font-size: 26px !important;
+        font-size: 24px !important;
         margin: 12px 0 20px;
       }
 
       .grid-layout .condition-title .v-icon {
-        font-size: 34px !important;
+        font-size: 30px !important;
       }
 
       /* 使い方・デモデータボタンを縮小する（インラインstyleに勝つため!important）。
          マイナスマージンはPC用の大きいタイトルに合わせた値のため、縮小後の高さに合わせて調整する */
       .v-navigation-drawer .sidebar-top-btn {
-        height: 36px !important;
-        font-size: 14px !important;
-        margin: -10px 0 0 8px !important;
-        padding: 0 12px !important;
+        height: 34px !important;
+        font-size: 13px !important;
+        margin: -8px 0 0 6px !important;
+        padding: 0 8px !important;
       }
 
       .v-navigation-drawer .sidebar-top-btn .v-icon {
-        font-size: 20px !important;
+        font-size: 17px !important;
+      }
+
+      .v-navigation-drawer .sidebar-top-btn .icon {
+        margin-right: 1px;
       }
 
       /* 条件パネルの見出しをコンパクトにする */


### PR DESCRIPTION
## 概要
スマホ表示で「使い方」「デモデータ」ボタンが複数行に折り返してしまう問題を修正しました。ボタンと「条件」見出しをわずかに縮小することで、`条件 / 使い方 / デモデータ` を1行に収めます。

## 変更内容
`@media screen and (max-width:600px)` 内のみを調整（[index.html](index.html) の該当ブロック）:

- 見出し「条件」: フォント 26→24px、アイコン 34→30px
- 使い方・デモデータボタン: 高さ 36→34px、フォント 14→13px、左マージン 8→6px、左右パディング 12→8px、アイコン 20→17px（アイコン右マージンも1pxに）

## 検証
実機相当のレンダリングで確認済み:
- iPhone標準幅(390px)・狭めの機種(375px)いずれも、閉じるボタン(≫)の手前に収まり折り返さない
- タブレット/PC(1280px)は元の値のまま（title 40px / button 20px 等）でデグレなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)