### PR TITLE
スマホ時の下部3ボタンのマージンを少し広げる

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,8 +279,8 @@
       .sidebar-bottom-sticky .v-btn {
         height: 34px !important;
         font-size: 13px !important;
-        margin: 4px 4px 4px 0 !important;
-        padding: 0 6px !important;
+        margin: 4px 7px 4px 0 !important;
+        padding: 0 5px !important;
       }
 
       .sidebar-bottom-sticky .v-btn .v-icon {


### PR DESCRIPTION
## 概要
スマホ表示で、下部3ボタン（席替え / コピペで入力 / 結果を復元）のボタン間マージンが詰まって見えたため、少し広げました。

## 変更内容
`@media screen and (max-width:600px)` 内の `.sidebar-bottom-sticky .v-btn`（[index.html](index.html)）:

- ボタン間マージン: 4px → 7px
- 内側パディング: 6px → 5px（1行維持のための微調整、見た目はほぼ不変）

## 検証
実機相当のレンダリングで確認済み:
- 375px・390px とも3ボタンは1行を維持し、NEWバッジもドロワー端の内側に収まる（375pxで6pxの余裕）
- 360px以下は変更前から2行に折り返す挙動で変化なし
- タブレット/PCへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)