### PR TITLE
スマホ時の下部3ボタンの間隔を使い方・デモデータの間隔に合わせる

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
       .sidebar-bottom-sticky .v-btn {
         height: 34px !important;
         font-size: 13px !important;
-        margin: 4px 7px 4px 0 !important;
+        margin: 4px 10px 4px 0 !important;
         padding: 0 5px !important;
       }
 


### PR DESCRIPTION
## 概要
スマホ表示時、下部3ボタン（席替え・コピペで入力・結果を復元）の間隔が、上部の「使い方／デモデータ」ボタンの間隔より狭く見えていたため、揃えました。

## 原因
実際にスマホ幅でレンダリングして計測したところ、隙間の実測値は以下の通りでした。

| ボタン群 | 隙間の実測値 |
|---|---|
| 使い方 ↔ デモデータ（正） | 10px |
| 席替え等（変更前 margin-right 7px） | 7px |

- 上部ボタンは inline-block で、HTMLの改行由来の**空白文字が約4px上乗せ**され、`margin-left:6px` でも実測10pxの隙間になっていた
- 下部ボタンは flex レイアウトで空白が無視されるため、margin値そのまま = 7px

## 変更内容
`index.html` の下部3ボタンの `margin-right` を `7px` → `10px` に変更し、上部と同じ10pxの隙間に揃えた。

## 確認
- 393px（iPhone標準幅）で上下とも隙間10px・3ボタン1行に収まることを確認
- 360px以下では元々（6px/7pxでも）3ボタン目が折り返す挙動で、本変更による悪化はなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)