### PR TITLE
席替え計算を非リアクティブ化してモバイルのINP（操作遅延）を改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -1593,8 +1593,6 @@
         seatsSizeY: 6, // デフォルト値は6
         seatsSizeX: 6, // デフォルト値は6
         seatsTable: [], // 座席テーブル、生徒名が入る二次元配列
-        seatsTableIndex: [], // 座席テーブル上の有効な座席のインデックス
-        dupSeatsTableIndex: [], // 座席テーブル上の有効な座席のインデックスの複製、席替えの際に破壊的にデータを取り出していく
         seatsNum: 0, // 有効な座席数
         seatsOptionsX: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], // よこの座席数入力フォームの選択肢
         seatsOptionsY: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], // たての座席数入力フォームの選択肢
@@ -1602,24 +1600,13 @@
         limitedSeatsOptionsY: [1, 2, 3, 4, 5, 6], // seatsSizeYのデフォルト値6に合わせて、選択肢のデフォルト値も6までにする
         distanceOptions: [0, 1, 2, 3, 4], // 近づける・離す距離の選択肢、デフォルト値6に合わせて実現可能な選択肢をデフォルトに設定
         studentsName: [], // 生徒の名前配列、席替えボタンが2回以上押されたときに元の生徒名を記憶しておくため
-        dupStudentsName: [], // 生徒の名前配列の複製、席替えの際に破壊的にデータを取り出していく
         nearConditions: [['', '', '']], // 近づける条件配列
         farConditions: [['', '', '']], // 離す条件用配列
-        dupNearFarStudentsName: [], // 近づける/離す生徒の名前の複製
         frontConditions: [''], // 最前列に固定する生徒
-        frontSeatsIndex: [], // 最前列のインデックス
-        dupFrontSeatsIndex: [], // 最前列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
         frontTwoRowsConditions: [''], // 前2列に固定する生徒
-        frontTwoRowsSeatsIndex: [], // 前2列のインデックス
-        dupFrontTwoRowsSeatsIndex: [], // 前2列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
         backConditions: [''], // 最後列に固定する生徒
-        backSeatsIndex: [], // 最後列のインデックス
-        dupBackSeatsIndex: [], // 最前列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
         backTwoRowsConditions: [''], // 後ろ2列に固定する生徒
-        backTwoRowsSeatsIndex: [], // 後ろ2列のインデックス
-        dupBackTwoRowsSeatsIndex: [], // 後ろ2列のインデックスの複製、席替えの際に破壊的にデータを取り出していく
         nextSeatsTable: [], // 席替え後の座席テーブル、生徒名が入る二次元配列
-        restartFlag: false, // 条件を満たしていないとき、changeSeats()の最初からリスタートする制御用フラグ
         genderTable: [], // 生徒の性別テーブル、性別が入る二次元配列
         genderArray: [], // 生徒の性別配列、テーブルを展開したもの、studentsName[]と順番が対応
         isAllDifferent: true, // 前回の座席と異なる配置にするかどうかの制御フラグ
@@ -1944,12 +1931,21 @@
         },
         changeSeats() { // メイン処理
           this.error = false; // 前回の実行で出したエラー表示を解除し、毎回クリーンな状態から始める
+          // 表示用テーブルを先にブランク化する。結果の反映はループ終了後の一括コピーなので、
+          // 途中で例外が起きた場合に前回の結果が「新しい結果」のように残って見えるのを防ぐ
+          this.resetNextSeatsTable();
           let loopNum = 0; // changeSeats()の処理を指定された回数繰り返す際に制御する変数
           do {
             loopNum += 1;
             this.restartFlag = false;
             this.calcNum = 0 // 無限ループ検出用の計算回数カウンタ（描画に使わないので非リアクティブな内部状態）
-            this.resetNextSeatsTable(); // 席替え後座席テーブルを初期化する
+            // 席替え後座席テーブルの計算用作業領域を空白で初期化する。
+            // リアクティブなnextSeatsTableへ直接書き込むと1回の席替えで数千回の監視処理が走るため、
+            // 計算は素の二次元配列で行い、ループ終了後に一度だけnextSeatsTableへ反映する
+            this.workNextSeatsTable = [];
+            for (let i = 0; i < this.seatsSizeY; i++) {
+              this.workNextSeatsTable.push(Array(this.seatsSizeX).fill(''));
+            }
             this.resetFrontSeatsIndex(); // 最前列インデックス配列を空にする
             this.resetFrontTwoRowsSeatsIndex(); // 前2列インデックス配列を空にする
             this.resetBackSeatsIndex(); // 最後列インデックス配列を空にする
@@ -1989,6 +1985,10 @@
             this.createNewBackConditions(); // 次回の準備、最後列のフォームを1つ作成
             this.createNewLeaderConditions(); // 次回の準備、班長のフォームを1つ作成
           } while (this.restartFlag && loopNum <= 500)
+          // 計算結果を一度だけリアクティブなnextSeatsTableへ反映する（行はコピーして渡し、表示用テーブルと作業領域を切り離す）
+          for (let i = 0; i < this.seatsSizeY; i++) {
+            this.nextSeatsTable.splice(i, 1, this.workNextSeatsTable[i].slice());
+          }
           this.$nextTick(function () { // DOMの更新を待ってからsortableJSをフォームにセット
             setTimeout(this.setSortableJS, 100); // setTimeout()で処理しないとセットされない
           });
@@ -2004,22 +2004,22 @@
           this.shuffle(this.dupSeatsTableIndex); // インデックスをシャッフル
           // 残った生徒に、元の並び（studentsName/genderArray/seatsTableIndex）から性別と元座席を割り当てる。
           // 同名の生徒がいても元インデックスを1人ずつ消費するので、性別や元座席を取り違えない（例: 男の山田と女の山田）。
-          const usedOriginalIndex = new Set();
+          // 名前→元インデックス一覧のMapを先に作り、名前ごとに先頭から順に消費する
+          // （「その名前でまだ使われていない最初のインデックス」という従来の割り当て順を保ったまま、restartごとの総当たり探索を避ける）
+          const originalIndexesByName = new Map();
+          this.studentsName.forEach((name, i) => {
+            if (!originalIndexesByName.has(name)) originalIndexesByName.set(name, []);
+            originalIndexesByName.get(name).push(i);
+          });
           const remainingStudents = this.dupStudentsName.map(name => {
-            let originalIndex = -1;
-            for (let i = 0; i < this.studentsName.length; i++) {
-              if (!usedOriginalIndex.has(i) && this.studentsName[i] === name) {
-                usedOriginalIndex.add(i);
-                originalIndex = i;
-                break;
-              }
-            }
+            // dupStudentsNameは毎パスstudentsNameから複製されて減る一方なので、名前ごとのインデックスは必ず残っている
+            const originalIndex = originalIndexesByName.get(name).shift();
             return { name, gender: this.genderArray[originalIndex], originalSeat: this.seatsTableIndex[originalIndex] };
           });
           remainingStudents.forEach(student => { // 生徒を一人取り出す
             let topIndex = this.dupSeatsTableIndex.shift(); // シャッフルしたインデックスを格納した配列の先頭を取り出す
             // 性別固定: 座席の性別が生徒の性別と一致するか／異なる席: 元の座席と違うか。満たさない間、別の座席を試す
-            while ((this.isFixGender && this.genderTable[topIndex[1]][topIndex[0]] !== student.gender) || (this.isAllDifferent && student.originalSeat.toString() === topIndex.toString())) {
+            while ((this.isFixGender && this.genderTable[topIndex[1]][topIndex[0]] !== student.gender) || (this.isAllDifferent && student.originalSeat[0] === topIndex[0] && student.originalSeat[1] === topIndex[1])) {
               if (this.calcNum > this.seatsNum) {
                 this.restartFlag = true;
                 break;
@@ -2028,15 +2028,15 @@
               topIndex = this.dupSeatsTableIndex.shift(); // 配列先頭のインデックスを再度取り出す
               this.calcNum += 1;
             }
-            this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, student.name); // 取り出したインデックスの位置に生徒名を保存
+            this.workNextSeatsTable[topIndex[1]][topIndex[0]] = student.name; // 取り出したインデックスの位置に生徒名を保存
           })
         },
-        shuffle(array) { // 配列をランダムにシャッフル
+        shuffle(array) { // 配列をランダムにシャッフル（呼び出し元はすべて非リアクティブな素の配列なので、直接代入で入れ替える）
           for (let i = array.length - 1; i >= 0; i--) {
             const j = Math.floor(Math.random() * (i + 1));
             const tempValue = array[i];
-            array.splice(i, 1, array[j]);
-            array.splice(j, 1, tempValue);
+            array[i] = array[j];
+            array[j] = tempValue;
           }
         },
         makeFrontSeatsIndex() {
@@ -2082,7 +2082,7 @@
         changeFrontSeats() { // 最前列に固定する生徒を席替え
           this.shuffle(this.dupFrontSeatsIndex);
           this.frontConditions.forEach(frontStudentName => {
-            if (this.getPositionFromNextSeatsTable(frontStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
+            if (this.getPositionFromWorkNextSeatsTable(frontStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
             if (!this.dupFrontSeatsIndex.length) { // 最前列に空き座席が残っていなければ配置できないので、restartFlagを立てて最初からやり直す（undefinedをshiftしてクラッシュするのを防ぐ）
               this.restartFlag = true;
               return;
@@ -2099,7 +2099,7 @@
               this.calcNum += 1;
             }
             // ----ここまで----
-            this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, frontStudentName); // 取り出したインデックスの位置に生徒名を保存
+            this.workNextSeatsTable[topIndex[1]][topIndex[0]] = frontStudentName; // 取り出したインデックスの位置に生徒名を保存
             this.removeFromArray(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
             this.removeFromArray(frontStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
             this.removeFromArray(frontStudentName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
@@ -2109,7 +2109,7 @@
         changeFrontTwoRowsSeats() { // 前2列に固定する生徒を席替え
           this.shuffle(this.dupFrontTwoRowsSeatsIndex);
           this.frontTwoRowsConditions.forEach(frontTwoRowsStudentName => {
-            if (this.getPositionFromNextSeatsTable(frontTwoRowsStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
+            if (this.getPositionFromWorkNextSeatsTable(frontTwoRowsStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
             if (!this.dupFrontTwoRowsSeatsIndex.length) { // 前2列に空き座席が残っていなければ配置できないので、restartFlagを立てて最初からやり直す（undefinedをshiftしてクラッシュするのを防ぐ）
               this.restartFlag = true;
               return;
@@ -2126,7 +2126,7 @@
               this.calcNum += 1;
             }
             // ----ここまで----
-            this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, frontTwoRowsStudentName); // 取り出したインデックスの位置に生徒名を保存
+            this.workNextSeatsTable[topIndex[1]][topIndex[0]] = frontTwoRowsStudentName; // 取り出したインデックスの位置に生徒名を保存
             this.removeFromArray(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
             this.removeFromArray(frontTwoRowsStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
             this.removeFromArray(frontTwoRowsStudentName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
@@ -2135,7 +2135,7 @@
         changeBackSeats() { // 最後列に固定する生徒を席替え
           this.shuffle(this.dupBackSeatsIndex);
           this.backConditions.forEach(backStudentName => {
-            if (this.getPositionFromNextSeatsTable(backStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
+            if (this.getPositionFromWorkNextSeatsTable(backStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
             if (!this.dupBackSeatsIndex.length) { // 最後列に空き座席が残っていなければ配置できないので、restartFlagを立てて最初からやり直す（undefinedをshiftしてクラッシュするのを防ぐ）
               this.restartFlag = true;
               return;
@@ -2152,7 +2152,7 @@
               this.calcNum += 1;
             }
             // ----ここまで----
-            this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, backStudentName); // 取り出したインデックスの位置に生徒名を保存
+            this.workNextSeatsTable[topIndex[1]][topIndex[0]] = backStudentName; // 取り出したインデックスの位置に生徒名を保存
             this.removeFromArray(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
             this.removeFromArray(backStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
             this.removeFromArray(backStudentName, this.dupNearFarStudentsName); // ここで配置した生徒はchangeNearFarSeats()で配置する必要がないため、生徒名を削除する
@@ -2162,7 +2162,7 @@
         changeBackTwoRowsSeats() { // 後ろ2列に固定する生徒を席替え
           this.shuffle(this.dupBackTwoRowsSeatsIndex);
           this.backTwoRowsConditions.forEach(backTwoRowsStudentName => {
-            if (this.getPositionFromNextSeatsTable(backTwoRowsStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
+            if (this.getPositionFromWorkNextSeatsTable(backTwoRowsStudentName) !== false) return; // 既にplaceLeaders()等で配置済みならスキップ
             if (!this.dupBackTwoRowsSeatsIndex.length) { // 後ろ2列に空き座席が残っていなければ配置できないので、restartFlagを立てて最初からやり直す（undefinedをshiftしてクラッシュするのを防ぐ）
               this.restartFlag = true;
               return;
@@ -2179,7 +2179,7 @@
               this.calcNum += 1;
             }
             // ----ここまで----
-            this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, backTwoRowsStudentName); // 取り出したインデックスの位置に生徒名を保存
+            this.workNextSeatsTable[topIndex[1]][topIndex[0]] = backTwoRowsStudentName; // 取り出したインデックスの位置に生徒名を保存
             this.removeFromArray(topIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除
             this.removeFromArray(backTwoRowsStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除
             this.removeFromArray(backTwoRowsStudentName, this.dupNearFarStudentsName); // ここで配置した生徒は、changeNearFarSeats()で配置する必要がないため、生徒名を削除する
@@ -2200,7 +2200,7 @@
               this.calcNum += 1;
             }
             // ----ここまで----
-            this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, dupNearFarStudentName); // 取り出したインデックスの位置に生徒名を保存
+            this.workNextSeatsTable[topIndex[1]][topIndex[0]] = dupNearFarStudentName; // 取り出したインデックスの位置に生徒名を保存
             this.removeFromArray(dupNearFarStudentName, this.dupStudentsName); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、生徒名を削除する
           })
         },
@@ -2210,7 +2210,7 @@
               const fixConditionName = fixCondition[0];
               const fixConditionRow = fixCondition[1] - 1; // 入力された値とインデックスのずれを補正
               const fixConditionCol = fixCondition[2] - 1; // 入力された値とインデックスのずれを補正
-              this.nextSeatsTable[fixConditionRow].splice(fixConditionCol, 1, fixConditionName); // 固定する場所に配置
+              this.workNextSeatsTable[fixConditionRow][fixConditionCol] = fixConditionName; // 固定する場所に配置
 
               const fixIndex = [fixConditionCol, fixConditionRow]
               this.removeFromArray(fixIndex, this.dupSeatsTableIndex); // ここで配置した生徒はshuffleSeats()で配置する必要がないため、有効な座席座標を削除する
@@ -2243,7 +2243,7 @@
           const groupHasLeader = {};
           const remainingLeaders = [];
           leaders.forEach(leaderName => {
-            const pos = this.getPositionFromNextSeatsTable(leaderName);
+            const pos = this.getPositionFromWorkNextSeatsTable(leaderName);
             if (pos !== false) {
               // 既にplaceFixedSeats()で配置済み
               const groupId = this.getGroupId(pos[0], pos[1]);
@@ -2352,7 +2352,7 @@
             // ----ここまで----
             if (this.restartFlag) return;
 
-            this.nextSeatsTable[topIndex[1]].splice(topIndex[0], 1, leaderName); // 取り出したインデックスの位置に班長名を保存
+            this.workNextSeatsTable[topIndex[1]][topIndex[0]] = leaderName; // 取り出したインデックスの位置に班長名を保存
 
             // ここで配置した班長は他の配置処理で配置する必要がないため、各配列から削除する
             this.removeFromArray(topIndex, this.dupSeatsTableIndex);
@@ -2382,7 +2382,7 @@
               }
               // ----ここまで----
               const distance = nearConditionArray[2] + 1; // 距離、表記とのズレを修正するために+1
-              const nearStudentPosition = this.getPositionFromNextSeatsTable(nearStudentName); // すでに配置されていればその座標、まだ配置されてなければfalse
+              const nearStudentPosition = this.getPositionFromWorkNextSeatsTable(nearStudentName); // すでに配置されていればその座標、まだ配置されてなければfalse
               if (nearStudentPosition === false) return; // 相手がまだ配置されていなければ、ここでは距離を判定しない（相手を配置する際に改めてチェックされる）
               if (this.maxDistance(p, nearStudentPosition) > distance) { // 距離のmaxが条件distanceより上なら返り値をfalseに更新
                 returnValue = false;
@@ -2404,7 +2404,7 @@
               }
               // ----ここまで----
               const distance = farConditionArray[2] + 1; // 距離、表記とのズレを修正するために+1
-              const farStudentPosition = this.getPositionFromNextSeatsTable(farStudentName); // すでに配置されていればその座標、まだ配置されてなければfalse
+              const farStudentPosition = this.getPositionFromWorkNextSeatsTable(farStudentName); // すでに配置されていればその座標、まだ配置されてなければfalse
               if (farStudentPosition === false) return; // 相手がまだ配置されていなければ、ここでは距離を判定しない（相手を配置する際に改めてチェックされる）
               if (this.maxDistance(p, farStudentPosition) < distance) { // 距離のminが条件distanceより下なら返り値をfalseに更新
                 returnValue = false;
@@ -2425,10 +2425,10 @@
           // 配列を比較するときは厳密比較になるので文字列に変換
           return currentIndex.toString() !== p.toString();
         },
-        getPositionFromNextSeatsTable(studentName) { // 引数の生徒が席替え後座席テーブルにすでにいればその座標を、いなければfalseを返す
+        getPositionFromWorkNextSeatsTable(studentName) { // 引数の生徒が席替え後座席テーブル（計算用の作業領域）にすでにいればその座標を、いなければfalseを返す
           let nextSeatsRowNum = 0; // 行インデックス、y座標
           let returnValue = false; // 返す値の初期値をfalse
-          this.nextSeatsTable.forEach(nextSeatsRow => {
+          this.workNextSeatsTable.forEach(nextSeatsRow => {
             if (nextSeatsRow.includes(studentName)) {
               const nextSeatsColNum = nextSeatsRow.indexOf(studentName);
               returnValue = [nextSeatsColNum, nextSeatsRowNum]; // 返す値を座標で更新
@@ -2640,6 +2640,25 @@
         },
       },
       created() {
+        // 席替え計算専用の作業領域。data()に置くとVueのリアクティブ配列になり、
+        // アルゴリズム内のsplice/shift/push（1回の席替えで数百〜数千回）が素の配列の約50倍遅くなる。
+        // これらはテンプレート・watch・computed・保存処理のいずれからも参照されない純粋な内部状態なので、
+        // インスタンスプロパティとして初期化し、非リアクティブにする（this.xxxでのアクセスは従来どおり）。
+        this.seatsTableIndex = []; // 座席テーブル上の有効な座席のインデックス
+        this.dupSeatsTableIndex = []; // 上記の複製、席替えの際に破壊的にデータを取り出していく
+        this.dupStudentsName = []; // 生徒の名前配列の複製、席替えの際に破壊的にデータを取り出していく
+        this.dupNearFarStudentsName = []; // 近づける/離す生徒の名前の複製
+        this.frontSeatsIndex = []; // 最前列のインデックス
+        this.dupFrontSeatsIndex = []; // 上記の複製
+        this.frontTwoRowsSeatsIndex = []; // 前2列のインデックス
+        this.dupFrontTwoRowsSeatsIndex = []; // 上記の複製
+        this.backSeatsIndex = []; // 最後列のインデックス
+        this.dupBackSeatsIndex = []; // 上記の複製
+        this.backTwoRowsSeatsIndex = []; // 後ろ2列のインデックス
+        this.dupBackTwoRowsSeatsIndex = []; // 上記の複製
+        this.workNextSeatsTable = []; // 席替え後座席テーブルの計算用作業領域。changeSeats()内で毎回作り直し、結果を最後に一度だけnextSeatsTableへ反映する
+        this.restartFlag = false; // 条件を満たしていないとき、changeSeats()の最初からリスタートする制御用フラグ
+
         this.makeSeatsTable(); // 最初にseatsTableを作成
         this.makeNextSeatsTable(); // 席替え後用のnextSeatsTableを空白で作成
         this.makeGenderTable(); // genderTableを作成


### PR DESCRIPTION
## 背景

Google Search Console で INP（Interaction to Next Paint）の問題「200ミリ秒超（モバイル）」が報告されていた。

計測の結果、原因は「席替え」ボタンのメインスレッド占有（デスクトップで113〜172ms、モバイル実機換算で約450ms〜1s）。内訳はDOM描画ではなく、席替えアルゴリズムがVueのリアクティブ配列上で `splice`/`shift`/`push` を大量実行していることによるもの（素の配列比で約50倍遅い）。

## 変更内容

- 席替え計算専用の中間配列13個を `data()` から `created()` のインスタンスプロパティへ移動し、非リアクティブ化（`this.xxx` での参照はそのまま。テンプレート・watch・computed・保存処理のいずれからも非参照であることを確認済み）
- 計算は素の作業テーブル `workNextSeatsTable` で行い、ループ終了後に一度だけリアクティブな `nextSeatsTable` へ反映
- `shuffleSeats` の生徒→元座席の対応付けを O(n²) 総当たりから Map ベースの O(n) に変更（同名生徒の割り当て順は従来と同一）
- `changeSeats` 冒頭で表示テーブルをブランク化（途中で例外が起きた場合に前回結果が新結果のように残るのを防ぐ）
- `getPositionFromWorkNextSeatsTable` へリネーム（実体が作業テーブル読みになったため）
- `shuffle()` のスワップを splice から直接代入に変更（呼び出し元がすべて非リアクティブ化されたため）

## 効果（デスクトップ実測・中央値）

| シナリオ | 変更前 | 変更後 |
|---|---|---|
| 6×6 デモ | 113ms | 0.3ms |
| 8×8 満席 | 172ms | 0.1ms |
| 12×12 満席 | 約440ms | 0.1ms |
| ボタン操作のロングタスク | 113〜172ms | 検出なし |

モバイルはCPUが4〜6倍遅い前提でも、アルゴリズム起因のINP要因は実質解消。

## 検証

- 既存のE2Eテスト43件すべてグリーン（全条件: 前後列・近づける/離す・固定・性別・班長・同名・保存復元・ドラッグ）
- 全員配置・条件充足の不変条件をブラウザ実測でも確認
- 8角度のコードレビュー（正確性3・クリーンアップ3・設計・規約）+ 指摘ごとの個別検証を実施し、確認された指摘4件を修正済み
- 例外時にブランク表示となること（失敗の可視性）を実ブラウザで確認

## 対象外（既存バグ・別対応）

- 生徒削除後に条件へ残った古い名前によるクラッシュ（男女固定OFF時のみ発動）
- グリッド縮小時に固定座席条件が範囲外のまま残る問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)