### PR TITLE
ユーザー補助改善: サイドバー項目・ボタン・リストボックスにアクセシブルネームを付与

### DIFF
--- a/index.html
+++ b/index.html
@@ -751,9 +751,9 @@
           <v-navigation-drawer fixed :width="sidebarWidth" color="#ededed" :mini-variant="!drawer"
             mini-variant-width="73px" right mobile-breakpoint="0">
             <v-list nav dense>
-              <v-list-item-group>
+              <v-list-item-group aria-label="条件">
                 <template v-if="drawer">
-                  <v-list-item style="float: right;" @click.stop="drawer = !drawer">
+                  <v-list-item style="float: right;" aria-label="条件パネルを閉じる" @click.stop="drawer = !drawer">
                     <v-icon color="#0c9ea8" class="close-icon"
                       style="font-size: 32px;">mdi-chevron-double-right</v-icon>
                   </v-list-item>
@@ -1176,14 +1176,14 @@
                 </template>
                 <!-- サイドバーを閉じたとき -->
                 <template v-else>
-                  <v-list-item @click.stop="drawer = !drawer;"
+                  <v-list-item aria-label="条件パネルを開く" @click.stop="drawer = !drawer;"
                     @click="isOpenSeatNumPanel=0; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                     <v-icon color="#0c9ea8" class="open-icon" style="font-size: 32px;">mdi-chevron-double-left</v-icon>
                   </v-list-item>
                   <div style="margin-bottom: 20px;"></div>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="座席数を指定する" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
                         @click="isOpenSeatNumPanel=0; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-grid</v-icon>
                       </v-list-item>
@@ -1192,7 +1192,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="前後で指定する" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=0; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-sort-ascending</v-icon>
                       </v-list-item>
@@ -1201,7 +1201,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="特定の座席に固定する" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=0; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-target-variant</v-icon>
                       </v-list-item>
@@ -1210,7 +1210,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="生徒同士を近づける" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=0; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-arrow-collapse</v-icon>
                       </v-list-item>
@@ -1219,7 +1219,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="生徒同士を離す" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=0; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-arrow-expand</v-icon>
                       </v-list-item>
@@ -1228,7 +1228,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="班長を指定する" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=0;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-account-star</v-icon>
                       </v-list-item>
@@ -1237,7 +1237,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-btn elevation="2" color="#FFFFFF" class="closed-btn" fab text @click="changeSeatsProcess();"
+                      <v-btn elevation="2" color="#FFFFFF" class="closed-btn" fab text aria-label="席を並び替える" @click="changeSeatsProcess();"
                         v-bind="attrs" v-on="on">
                         <v-icon style="font-size: 32px;">mdi-sync</v-icon>
                       </v-btn>
@@ -1535,7 +1535,7 @@
         </v-dialog>
 
         <!-- ランディング -->
-        <v-dialog v-model="landing" width="530" overlay-opacity="0.25">
+        <v-dialog v-model="landing" width="530" overlay-opacity="0.25" aria-label="席替えメーカーへようこそ">
           <v-card>
             <v-card-title class="headline teal lighten-2 font-weight-black"
               style="display: inherit; color: #FFFFFF; ">席替えメーカーへようこそ！</v-card-title>


### PR DESCRIPTION
## 概要

PageSpeed Insights(ユーザー補助 74点)の「名前が設定されていない」系の指摘に対応します。
**見た目に影響しない**アクセシブルネームの付与のみ。色変更を伴うコントラスト対応は別PRに分離します。

## 対応した監査項目

- **ARIA トグルフィールドに名前がない** → 折りたたみサイドバーのアイコンショートカット7項目(role=option)に `aria-label` を付与（座席数を指定する／前後で指定する／…／条件パネルを開く）
- **ARIA 入力フィールド(listbox)に名前がない** → `v-list-item-group`(role=listbox)に `aria-label="条件"` を付与
- **ボタンに名前がない** → 席並び替えボタン(`closed-btn`)に `aria-label="席を並び替える"` を付与

## 検証

Playwrightで各role要素にアクセシブルネームが実際に付与されたことを確認:
- role=option 7個すべてに名前あり
- role=listbox に「条件」
- closed-btn に「席を並び替える」
- 折りたたみサイドバー・ダイアログの表示崩れなし、コンソールエラーなし

## 本PRに含めていないもの（別対応）

- **コントラスト不足**（色変更を伴うため次の別PR）: 見出しの白文字onティール(2.56)、一括入力ボタン(3.24)、NEWバッジ(3.33)
- **ダイアログの名前 / aria-haspopup不一致 / 必須子role**: Vuetify 2.7 の `v-dialog` `v-list-item-group` 内部構造由来で、テンプレートでは修正不可（サイドバー再構築やVuetifyアップグレードが必要なため見送り）

🤖 Generated with [Claude Code](https://claude.com/claude-code)