### PR TITLE
ユーザー補助改善: サイドバーアイコンのaria属性不一致を解消

### DIFF
--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@
                   <div style="margin-bottom: 20px;"></div>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="座席数を指定する" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="座席数を指定する" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=0; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-grid</v-icon>
                       </v-list-item>
@@ -1192,7 +1192,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="前後で指定する" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="前後で指定する" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=0; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-sort-ascending</v-icon>
                       </v-list-item>
@@ -1201,7 +1201,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="特定の座席に固定する" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="特定の座席に固定する" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=0; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-target-variant</v-icon>
                       </v-list-item>
@@ -1210,7 +1210,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="生徒同士を近づける" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="生徒同士を近づける" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=0; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-arrow-collapse</v-icon>
                       </v-list-item>
@@ -1219,7 +1219,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="生徒同士を離す" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="生徒同士を離す" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=0; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-arrow-expand</v-icon>
                       </v-list-item>
@@ -1228,7 +1228,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="班長を指定する" @click.stop="drawer = !drawer;" v-bind="attrs" v-on="on"
+                      <v-list-item aria-label="班長を指定する" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=0;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-account-star</v-icon>
                       </v-list-item>


### PR DESCRIPTION
## 概要

PageSpeed Insights(ユーザー補助 85点)の「`[aria-*]` 属性は役割と一致していません」の指摘に対応します。**見た目・動作に影響なし**。

## 原因

折りたたみサイドバーの6つのアイコンは `v-tooltip` のアクティベータになっており、`v-bind="attrs"` によって `role="option"` の要素に `aria-haspopup="true"` / `aria-expanded="false"` が付与されていました。これらは `role="option"` では無効な属性のため指摘されていました（ツールチップの無いアイコンだけは指摘対象外だったことからも、ツールチップ由来と特定）。

## 修正

各アクティベータから `v-bind="attrs"`（aria属性のみを渡す）を外し、`v-on="on"`（イベント）は維持しました。

- ツールチップはホバーで従来どおり表示（トリガーは `on` 側）
- クリックによるドロワー開閉・パネル展開も従来どおり
- 各項目の `aria-label` は維持されるため、読み上げ内容は不変（むしろ無効属性が消えて適正化）

## 検証（Playwright）

- `aria-haspopup` / `aria-expanded` が6項目すべてから除去（残り0）
- 全7 option に `aria-label` 維持
- ツールチップがホバーで表示されることを確認
- アイコンクリックでドロワーが開くことを確認
- 表示崩れ・コンソールエラーなし

## 本PRに含めないもの

- **必須の子role**（`role=list`/`listbox` の子要素）: Vuetify の `v-list`/`v-list-item-group` の構造由来で、サイドバー再構築が必要なため見送り
- **ダイアログの名前**: Vuetify 2.7 の `v-dialog` が属性を伝播しないため見送り
- **コントラスト**: 色変更を伴うため別PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)