### PR TITLE
ユーザー補助改善: サイドバーの誤ったlist/listbox/optionロールを解消

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,10 +750,10 @@
         <div>
           <v-navigation-drawer fixed :width="sidebarWidth" color="#ededed" :mini-variant="!drawer"
             mini-variant-width="73px" right mobile-breakpoint="0">
-            <v-list nav dense>
-              <v-list-item-group aria-label="条件">
+            <v-list nav dense role="presentation">
+              <v-list-item-group role="presentation">
                 <template v-if="drawer">
-                  <v-list-item style="float: right;" aria-label="条件パネルを閉じる" @click.stop="drawer = !drawer">
+                  <v-list-item style="float: right;" aria-label="条件パネルを閉じる" role="button" @click.stop="drawer = !drawer">
                     <v-icon color="#0c9ea8" class="close-icon"
                       style="font-size: 32px;">mdi-chevron-double-right</v-icon>
                   </v-list-item>
@@ -1176,14 +1176,14 @@
                 </template>
                 <!-- サイドバーを閉じたとき -->
                 <template v-else>
-                  <v-list-item aria-label="条件パネルを開く" @click.stop="drawer = !drawer;"
+                  <v-list-item aria-label="条件パネルを開く" role="button" @click.stop="drawer = !drawer;"
                     @click="isOpenSeatNumPanel=0; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                     <v-icon color="#0c9ea8" class="open-icon" style="font-size: 32px;">mdi-chevron-double-left</v-icon>
                   </v-list-item>
                   <div style="margin-bottom: 20px;"></div>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="座席数を指定する" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="座席数を指定する" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=0; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-grid</v-icon>
                       </v-list-item>
@@ -1192,7 +1192,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="前後で指定する" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="前後で指定する" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=0; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-sort-ascending</v-icon>
                       </v-list-item>
@@ -1201,7 +1201,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="特定の座席に固定する" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="特定の座席に固定する" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=0; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-target-variant</v-icon>
                       </v-list-item>
@@ -1210,7 +1210,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="生徒同士を近づける" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="生徒同士を近づける" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=0; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-arrow-collapse</v-icon>
                       </v-list-item>
@@ -1219,7 +1219,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="生徒同士を離す" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="生徒同士を離す" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=0; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-arrow-expand</v-icon>
                       </v-list-item>
@@ -1228,7 +1228,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="班長を指定する" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="班長を指定する" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=0;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-account-star</v-icon>
                       </v-list-item>


### PR DESCRIPTION
## 概要

PageSpeed Insights(ユーザー補助)の「ARIA `[role]` が指定されている要素に必要な子要素が指定されていない」の指摘に対応します。**見た目・動作に影響なし**。

> ⚠️ このPRは #330 の上に積んでいます（base = `a11y/aria-mismatch`）。#330 をマージ後、本PRは自動で master 向けに切り替わります。

## 原因

条件サイドバーは `v-list` / `v-list-item-group` を「アイコンショートカット＋フォーム」の汎用コンテナとして使っています。しかし Vuetify はこれらに以下のロールを付与します:

- `v-list` → `role="list"`（`listitem` の子が必要）
- `v-list-item-group` → `role="listbox"`（`option` の子が必要）

実際の子はフォーム・ボタン・展開パネルで、これらの必須子要素の要件を満たさないため指摘されていました。

## 修正

- `v-list` と `v-list-item-group` に `role="presentation"` を付与し、誤ったリスト/リストボックスのセマンティクスを無効化
- 各 `v-list-item`（実体は操作ボタン）に `role="button"` を付与。これにより「親のない `option`」として孤立することも防止

コンポーネント自体は残す（削除しない）ため、スタイル・機能は完全に維持されます。属性のみの追加です。

## 検証（Playwright）

- `role=list` / `role=listbox` / `role=option` がサイドバーから消滅（展開・折りたたみ両方で **0**）
- 全項目が `role="button"` + `aria-label` を保持
- ツールチップがホバーで表示、アイコンクリックでドロワー開閉・該当パネル展開が従来どおり動作
- 初期状態・展開・折りたたみとも**表示崩れなし**、コンソールエラーなし

## 残り

- **ダイアログの名前**: Vuetify 2.7 の `v-dialog` が属性を伝播しないため見送り
- **コントラスト**: 色変更を伴うため別PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)