### PR TITLE
ユーザー補助改善: サイドバーの誤ったlist/listbox/optionロールを解消（#331の再適用）

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,10 +750,10 @@
         <div>
           <v-navigation-drawer fixed :width="sidebarWidth" color="#ededed" :mini-variant="!drawer"
             mini-variant-width="73px" right mobile-breakpoint="0">
-            <v-list nav dense>
-              <v-list-item-group aria-label="条件">
+            <v-list nav dense role="presentation">
+              <v-list-item-group role="presentation">
                 <template v-if="drawer">
-                  <v-list-item style="float: right;" aria-label="条件パネルを閉じる" @click.stop="drawer = !drawer">
+                  <v-list-item style="float: right;" aria-label="条件パネルを閉じる" role="button" @click.stop="drawer = !drawer">
                     <v-icon color="#0c9ea8" class="close-icon"
                       style="font-size: 32px;">mdi-chevron-double-right</v-icon>
                   </v-list-item>
@@ -1176,14 +1176,14 @@
                 </template>
                 <!-- サイドバーを閉じたとき -->
                 <template v-else>
-                  <v-list-item aria-label="条件パネルを開く" @click.stop="drawer = !drawer;"
+                  <v-list-item aria-label="条件パネルを開く" role="button" @click.stop="drawer = !drawer;"
                     @click="isOpenSeatNumPanel=0; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                     <v-icon color="#0c9ea8" class="open-icon" style="font-size: 32px;">mdi-chevron-double-left</v-icon>
                   </v-list-item>
                   <div style="margin-bottom: 20px;"></div>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="座席数を指定する" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="座席数を指定する" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=0; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-grid</v-icon>
                       </v-list-item>
@@ -1192,7 +1192,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="前後で指定する" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="前後で指定する" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=0; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-sort-ascending</v-icon>
                       </v-list-item>
@@ -1201,7 +1201,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="特定の座席に固定する" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="特定の座席に固定する" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=0; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-target-variant</v-icon>
                       </v-list-item>
@@ -1210,7 +1210,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="生徒同士を近づける" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="生徒同士を近づける" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=0; isOpenFarPanel=1; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-arrow-collapse</v-icon>
                       </v-list-item>
@@ -1219,7 +1219,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="生徒同士を離す" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="生徒同士を離す" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=0; isOpenLeaderPanel=1;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-arrow-expand</v-icon>
                       </v-list-item>
@@ -1228,7 +1228,7 @@
                   </v-tooltip>
                   <v-tooltip left>
                     <template v-slot:activator="{ on, attrs }">
-                      <v-list-item aria-label="班長を指定する" @click.stop="drawer = !drawer;" v-on="on"
+                      <v-list-item aria-label="班長を指定する" role="button" @click.stop="drawer = !drawer;" v-on="on"
                         @click="isOpenSeatNumPanel=1; isOpenFrontBackPanel=1; isOpenPlaceFixPanel=1; isOpenNearPanel=1; isOpenFarPanel=1; isOpenLeaderPanel=0;">
                         <v-icon color="#0c9ea8" class="closed-icon" style="font-size: 32px;">mdi-account-star</v-icon>
                       </v-list-item>


### PR DESCRIPTION
## 概要

PR #331 の変更を master に正しく取り込むための再適用PRです。

#331 は base が `a11y/aria-mismatch` のままマージされてしまい（#330 マージ直後の自動リターゲット前にマージされたため）、GitHub上は「MERGED」ですが変更が master に届いていませんでした。本PRで同一のコミットを master に対して適用し直します。

## 変更内容（#331 と完全に同一・検証済み）

PageSpeed Insights(ユーザー補助)の「ARIA `[role]` に必要な子要素が指定されていない」指摘への対応:

- `v-list` / `v-list-item-group` に `role="presentation"` を付与し、誤った list/listbox のセマンティクスを無効化
- 各 `v-list-item`（実体は操作ボタン）に `role="button"` を付与し、孤立した `option` を防止

コンポーネント自体は残すため、スタイル・機能は完全に維持されます（属性のみの変更）。

## 検証（Playwrightで実施済み・#330との結合状態でも確認）

- `role=list` / `listbox` / `option` がサイドバーから消滅（展開・折りたたみ両方で0）
- 全項目が `role="button"` + `aria-label` を保持
- 6ツールチップすべてがホバー・キーボードフォーカスで表示
- «開く / »閉じるボタン・並び替えボタン・パネル展開が従来どおり動作
- 初期状態・展開・折りたたみとも表示崩れなし、コンソールエラーなし（既存の非推奨metaタグ警告1件を除く）
- 保存リストなど他の `v-list` は未変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)