### PR TITLE
非推奨のapple-mobile-web-app-capable警告を解消（標準タグを併記）

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <link rel="icon" href="favicon.ico">
   <link rel="manifest" href="/manifest.json">
   <meta name="theme-color" content="#0c9ea8">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <meta name="apple-mobile-web-app-title" content="席替えメーカー">


### PR DESCRIPTION
## 概要

Chromeが出力する非推奨警告に対応します。

> `<meta name="apple-mobile-web-app-capable" content="yes">` is deprecated. Please include `<meta name="mobile-web-app-capable" content="yes">`

## 変更内容

標準の `<meta name="mobile-web-app-capable" content="yes">` を1行追加（併記）しました。iOS向けの `apple-mobile-web-app-capable` は**残します**。

```html
<meta name="mobile-web-app-capable" content="yes">      <!-- 追加（標準・Chromium系） -->
<meta name="apple-mobile-web-app-capable" content="yes"> <!-- 維持（iOS用） -->
```

## なぜ両方残すのか

- iOS Safari はスタンドアロン表示に `apple-mobile-web-app-capable` を今も参照するため、削除するとiOSのPWA動作が壊れる
- 標準タグを併記するだけでChromeの非推奨警告は消える（実機確認済み）

## 検証（Playwright）

- 変更後、コンソールの警告が **0**（従来はこの非推奨警告1件のみ）
- エラー0、見た目・動作への影響なし（headのメタタグのみの変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)