### PR TITLE
ユーザー補助改善: ようこそダイアログ(role=dialog)にアクセシブルネームを付与

### DIFF
--- a/index.html
+++ b/index.html
@@ -2657,6 +2657,16 @@
           const minutes = ('0' + d.getMinutes()).slice(-2);
           return year + '/' + month + '/' + day + ' ' + hours + ':' + minutes;
         },
+        labelActiveDialogs() { // Vuetify2のv-dialogはrole="dialog"要素へ名前を付与する手段がないため、開いているダイアログにv-card__titleからアクセシブルネームを補う
+          this.$nextTick(function () {
+            document.querySelectorAll('.v-dialog__content--active[role="dialog"]').forEach(function (el) {
+              if (el.getAttribute('aria-label') || el.getAttribute('aria-labelledby')) return; // 既に名前があれば触らない
+              const title = el.querySelector('.v-card__title');
+              const name = title && title.textContent.trim();
+              if (name) el.setAttribute('aria-label', name);
+            });
+          });
+        },
       },
       created() {
         // 席替え計算専用の作業領域。data()に置くとVueのリアクティブ配列になり、
@@ -2719,9 +2729,13 @@
       },
       mounted() {
         this.setSortableJS(); // sortableJSをフォームにセット
+        this.labelActiveDialogs(); // 初期表示されるようこそダイアログにアクセシブルネームを付与
         // this.startTutorial();
       },
       watch: {
+        landing: function (val) { // ようこそダイアログが開いたらアクセシブルネームを付与
+          if (val) this.labelActiveDialogs();
+        },
         seatsTable: {
           handler: function () {
             this.studentsName = Array.prototype.concat.apply([], this.seatsTable); //seatsTableを展開


### PR DESCRIPTION
## 概要

PageSpeed Insights の「エージェントによるブラウジング」および「ユーザー補助」で指摘される **「ARIA dialog and alertdialog nodes should have an accessible name」** に対応します。

自動表示される「ようこそ」ダイアログ（`role="dialog"`）に名前が無く、スクリーンリーダー/AIエージェントが用途を識別できない状態でした。

## 実装方法（Vuetifyの制約への対処）

Vuetify 2.7 の `v-dialog` は `role="dialog"` を持つ内部要素（`.v-dialog__content`）へ `aria-label` を伝播する手段がありません（テンプレートに `aria-label` を書いても届かない）。そのため、**開いているダイアログに `v-card__title` のテキストから `aria-label` を補う**メソッド `labelActiveDialogs()` を追加しました。

- `mounted()`（初期表示されるようこそダイアログ）と `landing` の watch から呼び出し
- 既に `aria-label` / `aria-labelledby` を持つ要素には触らない（冪等）
- タイトルテキストをそのまま名前に使うため、表示内容と一致

## 検証（Playwright）

- 初期表示・再表示ともダイアログに `aria-label="席替えメーカーへようこそ！"` が付与されることを確認
- ダイアログの表示・スキップ/使い方を確認ボタンの動作は不変
- 表示崩れ・コンソールエラーなし
- 差分は14行の純粋な追加のみ（既存コードの変更なし）

## 補足

`labelActiveDialogs()` は汎用実装（開いている任意のダイアログをタイトルから命名）のため、他ダイアログにも展開可能ですが、本PRでは PSI がスキャンする自動表示ダイアログ（ようこそ）に絞って呼び出しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)