### PR TITLE
スマホの席替えボタン左端を他要素に揃える

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,14 +309,16 @@
         /* ボタンのNEWバッジが領域上端からはみ出し、
            背後を流れるコンテンツに重なるのを防ぐためののりしろ */
         padding-top: 6px;
+        /* 席替えボタンの左端を、下段のリンク行や上部の条件カードと同じ位置に揃える
+           （first-childのv-btnはmargin-left:0のため、左余白はここでまとめて確保する） */
+        padding-left: 10px;
       }
 
       /* 利用規約などのリンク行は全幅で最下段に置く（ボタンの下に折り返す）。
-         padding-leftは折り返した行（フィードバック等）の左端も利用規約と揃えるための共通余白 */
+         左余白は親.sidebar-bottom-stickyのpadding-leftで席替えボタンと共通化している */
       .sidebar-bottom-sticky>div {
         flex-basis: 100%;
         min-width: 0;
-        padding-left: 10px;
       }
 
       /* 利用規約のインラインmargin-leftを打ち消す（左余白は上のpadding-leftで共通化） */


### PR DESCRIPTION
## 概要

スマホ表示で、席替えボタンの左端が他の要素より左にはみ出していたのを、下段のリンク行・上部の条件カードと同じ左端に揃えました。

原因は、席替えボタン（`.sidebar-bottom-sticky` 内の first-child の `.v-btn`）が `margin-left: 0` のため、`padding-left: 10px` を持つ下段リンク行より10px左に出ていたことです。

## 変更内容

`@media screen and (max-width:600px)` ブロック内で:

- `.sidebar-bottom-sticky` に `padding-left: 10px` を追加し、ボタン行の左端を10pxに揃える
- `.sidebar-bottom-sticky>div`（リンク行）の重複する `padding-left: 10px` を除去（親のpaddingで共通化）

## デグレ対策

変更はすべて `max-width:600px`（スマホ）のメディアクエリ内に限定しており、タブレット・PC用のレイアウトには一切影響しません。Playwrightで390px（スマホ）と800px（タブレット）を確認し、スマホは左端が揃い・3ボタンは1行維持、タブレットは従来のまま変化なしを目視確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)