### PR TITLE
style: ダイアログ見出しの緑をサービス基調色に統一

### DIFF
--- a/index.html
+++ b/index.html
@@ -711,9 +711,9 @@
       z-index: 1;
     }
 
-    /* ダイアログ見出しの teal を少し濃くして白文字とのコントラストを確保（Vuetifyの teal lighten-2 を上書き） */
+    /* ダイアログ見出しの teal をサービス基調色に合わせて統一（Vuetifyの teal lighten-2 を上書き。白文字＋大見出しでWCAG 3:1をクリア） */
     .v-card__title.teal.lighten-2 {
-      background-color: #44A097 !important;
+      background-color: #0c9ea8 !important;
     }
   </style>
 </head>


### PR DESCRIPTION
## 概要
ダイアログ見出しの緑（`#44A097`）が、ボタン・アイコン・ロゴで使われているサービス基調色（`#0c9ea8`）から浮いていたため、基調色に統一しました。

## 変更内容
- `.v-card__title.teal.lighten-2` の背景色 `#44A097` → `#0c9ea8`
- 影響するダイアログ: 「新機能のお知らせ」「結果を保存」など `teal lighten-2` を使う見出し全て

## コントラスト
白文字＋大見出し（headline / font-weight-black）で約3.2:1 となり、WCAG大文字基準（3:1）をクリア。従来の `#44A097`（約3.1:1）と同等以上を維持しています。

## 補足
ピンク系（席替えボタン `#B82E73` / NEWバッジ `#D4356B`）は今回統一せず現状維持としています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)