### PR TITLE
chore: sortablejs を 1.15.7 に更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -1571,7 +1571,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/vue@2.7.16/dist/vue.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/vuetify@2.7.2/dist/vuetify.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.7/Sortable.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/intro.js@3.3.1/intro.min.js"></script>
 
   <script>


### PR DESCRIPTION
## 概要

sortablejs を `1.15.6` → `1.15.7` に更新します。パッチ更新のみで破壊的変更はありません。

## 変更内容

- index.html の CDN 参照バージョンを更新

## テスト

- [ ] ドラッグ&ドロップによる席の入れ替え動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)