### PR TITLE
chore: intro.js を 7.2.0 に更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,10 +51,10 @@
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.9.95/css/materialdesignicons.min.css" rel="stylesheet">
   </noscript>
   <link href="https://cdn.jsdelivr.net/npm/vuetify@2.7.2/dist/vuetify.min.css" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/3.3.1/introjs.min.css" rel="stylesheet" type="text/css"
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/7.2.0/introjs.min.css" rel="stylesheet" type="text/css"
     media="print" onload="this.media='all'">
   <noscript>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/3.3.1/introjs.min.css" rel="stylesheet" type="text/css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/7.2.0/introjs.min.css" rel="stylesheet" type="text/css">
   </noscript>
   <!-- 構造化データ: WebApplication -->
   <script type="application/ld+json">
@@ -1572,7 +1572,7 @@
   <script src="https://cdn.jsdelivr.net/npm/vue@2.7.16/dist/vue.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/vuetify@2.7.2/dist/vuetify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.7/Sortable.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/intro.js@3.3.1/intro.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/intro.js@7.2.0/intro.min.js"></script>
 
   <script>
     // ブレークポイント定数


### PR DESCRIPTION
## 概要

チュートリアル機能で使っている intro.js を `3.3.1` → `7.2.0` に更新します。**CDN のバージョン参照の変更のみ**で、アプリ側コードの書き換えは不要です（v8 未満は API 全互換）。

## 変更内容

- index.html の CDN 参照バージョンを更新（CSS 2箇所・JS 1箇所）

## 互換性の根拠（配布ファイルで実証確認）

現在使っている API が v7 まで維持されていることを、各メジャーバージョンの配布 JS/CSS を取得して確認しました。

| 使用API | v3.3.1 | v7.2.0 |
|---|---|---|
| `introJs()` / `setOptions` / `onafterchange` / `oncomplete` / `start` | ✅ | ✅ |
| 内部プロパティ `this._currentStep`（ステップ連動に使用） | ✅ | ✅ |
| CSSクラス `.introjs-tooltip` / `.introjs-overlay` | ✅ | ✅ |

- **v8 は見送り**: `introJs()` が非推奨になり新 API `introJs.tour()` への書き換えと `_currentStep` 依存の解消が必要なため、別タスクとします。

## テスト（PC・スマホ・タブレットで実機確認）

ローカルでブラウザからチュートリアルを一巡して目視確認済み。各ビューポートで挙動を確認しました。

| 検証項目 | PC | スマホ(390px) | タブレット(768px) |
|---|---|---|---|
| ステップ1〜5 の吹き出し・プログレスバー・ハイライト・ラベル | ✅ | ✅ | ✅ |
| SP/TB固有のサイドバー折りたたみ（`_currentStep` 連動） | – | ✅ | ✅ |
| デモデータ投入・席替え実行・終了処理 | ✅ | ✅ | ✅ |
| コンソールエラー・警告 | なし | なし | なし |

### 既知の事象（本PRの対象外・回帰ではない）

スマホ表示の「4. 席替え！」ステップで吹き出しが細く潰れる事象がありますが、**元の 3.3.1 でも同一に発生する既存の問題**であることを確認済みです（席替えボタンが左下隅にあり吹き出し幅を確保できないため）。本アップグレードによる回帰ではないため、別PRで対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)