### PR TITLE
fix: スマホでチュートリアル吹き出しの潰れ・画面外を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,6 +345,26 @@
         min-width: 0;
         max-width: 90vw;
       }
+
+      /* スマホで、画面端の要素を指すステップ(座席数・席替え)は intro.js が吹き出しを
+         画面外に置いたり極端に細く潰す。JS側で付けた専用クラスの吹き出しだけを画面中央に固定し、
+         読みやすい幅にする（要素のハイライトは intro.js の配置のまま維持される）。
+         intro.jsがインラインで付与する位置・幅に勝つため!importantが必須。 */
+      .introjs-tooltip.sp-tooltip-center {
+        position: fixed !important;
+        top: 50% !important;
+        left: 50% !important;
+        margin: 0 !important;
+        transform: translate(-50%, -50%) !important;
+        width: 300px !important;
+        max-width: 90vw !important;
+      }
+
+      /* 中央に寄せた吹き出しの矢印は対象要素を指せないので隠す */
+      .introjs-tooltip.sp-tooltip-center .introjs-arrow {
+        display: none !important;
+      }
+
     }
 
     @media screen and (min-width:601px) and (max-width:1020px) {
@@ -1705,6 +1725,16 @@
                 app.changeSeatsProcess();
               }
             }).start();
+            // 「座席数」(1番目)「席替え」(4番目)は画面端の要素を指すため、スマホでは intro.js が
+            // 吹き出しを画面外に置いたり極端に細く潰す。専用クラスを付け、実際に中央へ寄せるかは
+            // CSSのメディアクエリ(max-width:600px)に委ねる。こうすると画面幅（回転・リサイズ）に
+            // 自動で追従する（要素のハイライトは intro.js の配置のまま維持される）。
+            [0, 3].forEach(function (i) {
+              if (intro._introItems[i]) intro._introItems[i].tooltipClass = 'sp-tooltip-center';
+            });
+            // tooltipClass は表示済みの1番目のステップには反映されないため直接付与する
+            const shownTooltip = document.querySelector('.introjs-tooltip');
+            if (shownTooltip) shownTooltip.classList.add('sp-tooltip-center');
           })
           intro.oncomplete(function () {
             app.setBlankData();


### PR DESCRIPTION
## 概要

スマホ表示でチュートリアルの一部ステップの吹き出しが、極端に細く潰れて読めなかったり、画面外に配置されて操作できなかった問題を修正します。

対象要素が画面端にある **「座席数」(1番目) と「席替え」(4番目)** のステップで、intro.js が吹き出しをうまく配置できないことが原因です（intro.js 3.3.1 から存在する既存の表示崩れで、7.2.0 でも同様。#340 の回帰ではありません）。

## 変更方針

この2ステップの吹き出しにだけ専用クラス `sp-tooltip-center` を付け、**実際に画面中央へ寄せるかは CSS のメディアクエリ (`max-width:600px`) に委ねます**。これにより画面幅（回転・リサイズ）に自動追従し、JS側での画面幅判定を持ちません。**intro.js の要素ハイライト（対象要素の強調）はそのまま維持**されます。他のステップは変更しません。

- **JS**: 該当2ステップの `tooltipClass` に `sp-tooltip-center` を付与（表示中の先頭ステップには反映されないため直接 `classList.add` も実施）
- **CSS**: `@media max-width:600px` 内で、専用クラスの吹き出しだけを画面中央へ `position:fixed` で固定し、読みやすい幅に上書き（矢印は非表示）
- スマホ幅（≤600px）でのみ中央化が効き、タブレット・PC ではクラスは付くが CSS が無効（メディアクエリ外）なので **表示は master と同一**

### サイドバーを閉じる案について（不採用）

「名前を入力」ステップでサイドバーを閉じる案も検討・実装しましたが、**intro.js 7.2.0 ではサイドバーを閉じると後続の「条件」「席替え」ステップで対象要素のハイライトが失われる**ことが判明しました（閉じた瞬間に対象要素がサイズ0になり、intro.js が「中央フローティング（ハイライトなし）」扱いに固定してしまい、Vueの非同期描画・トランジションの都合で後から復帰できない）。ハイライト維持を優先し、サイドバーは閉じない方針としています。

## テスト（実機で各ステップのハイライト・吹き出し幅・画面内判定を計測）

スマホ(390px)の最終挙動:

| Step | 吹き出し | 幅 | ハイライト |
|---|---|---|---|
| 1 座席数 | 中央固定 | 300 | ✅ パネル |
| 2 名前入力 | 添付 | 332 | ✅ 座席表 |
| 3 条件 | 添付 | 326 | ✅ 条件パネル |
| 4 席替え | 中央固定 | 300 | ✅ 席替えボタン |
| 5 最終調整 | 添付 | 317 | ✅ 結果表 |

- 390px→800px のリサイズで中央固定が解除（`fixed`→`absolute`）され、画面幅に追従することを確認。
- タブレット(768px)・PC(1440px): クラスは付くが CSS 無効のため通常配置（`absolute`・矢印表示）で master と同一。
- スマホで全5ステップ＋終了まで通し確認。コンソールエラー・警告なし。

## 既知の残課題（低優先・別対応可）

- チュートリアル表示中に端末を回転させると、intro.js 自体がリサイズ時に再配置しないため吹き出しが回転前の位置に残ることがある（本PRで悪化はせず、むしろ中央化のON/OFFは追従するよう改善）。
- 中央化の対象ステップはインデックス `[0, 3]` で指定しているため、将来チュートリアルの順序を変える場合は注意が必要。
- 601〜1020px 幅は中央化の対象外（アプリのSP定義 ≤600px と一貫。768px では潰れないことを確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)