### PR TITLE
fix: スマホ・タブレットの結果を保存ボタンのNEWチップ位置を調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -1358,7 +1358,7 @@
         <div class="save-btn-container-tb">
           <v-btn elevation="2" x-large color="#0c9ea8" dark @click="openSaveDialog()"
             style="font-size: 20px; font-weight: 900;">
-            <span class="new-badge">NEW</span>
+            <span class="new-badge" style="right: -32px;">NEW</span>
             <v-icon left>mdi-content-save</v-icon>結果を保存
           </v-btn>
         </div>


### PR DESCRIPTION
## 概要

スマホ・タブレット表示の「結果を保存」ボタンの NEW チップが、他のボタンに比べて左にずれていた問題を修正します。

## 原因

`save-btn-container-tb` 内の「結果を保存」ボタンの NEW バッジはデフォルトの `right: -18px` のままでした。一方、隣接する「コピペで入力」「結果を復元」ボタンには `padding-right: 15px` が付いており、それらのバッジが約15px右にずれて表示されるため、「結果を保存」だけが左にずれて見えていました。

## 変更内容

PC版と同じ `right: -32px` を指定し、他ボタンの NEW チップと位置を揃えました。

## 補足（レビュー指摘事項）

`-32px` はタブレット幅で他ボタンと揃う値です。スマホ幅（max-width:600px）では隣接ボタンが `padding: 0 5px` に上書きされコンパクト化されるため厳密には条件が異なりますが、まずはユーザーの指摘（もう少し右へ）に合わせた最小変更としています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)