### PR TITLE
feat: 席替え結果の座席表を印刷できるようにする

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,14 +185,23 @@
       /* 絶対配置のままだと画面外にはみ出すため、タイトル横の通常フローに戻す。
          staticではなくrelativeにするのは、子のNEWバッジ（絶対配置）の基準を
          このボタンのまま保つため（staticだと基準が外側のタイトルspanに変わってずれる）。
-         relativeはインラインのleft/topをオフセットとして適用してしまうため、両方打ち消す */
+         relativeはインラインのleft/topをオフセットとして適用してしまうため、両方打ち消す。
+         大きさはサイドバー下部のボタンと同じに縮小する */
       .bulk-input-btn {
         position: relative !important;
         left: 0 !important;
         top: 0 !important;
         transform: none !important;
         margin-left: 10px !important;
-        font-size: 1rem !important;
+        height: 34px !important;
+        font-size: 13px !important;
+        padding: 0 8px !important;
+      }
+
+      /* NEWバッジの位置も縮小したボタンの右上角（デフォルト位置）に合わせる */
+      .bulk-input-btn .new-badge {
+        top: -18px !important;
+        right: -18px !important;
       }
 
       /* 座席マスを縮小し、横スクロールなしで6列全体が見えるようにする
@@ -298,6 +307,29 @@
 
       .sidebar-bottom-sticky .v-btn .v-icon {
         font-size: 17px !important;
+      }
+
+      /* 結果を保存・印刷ボタンも、サイドバー下部のボタンと同じ大きさに縮小する
+         （インラインstyleに勝つため!important） */
+      .save-btn-container-tb .v-btn {
+        height: 34px !important;
+        font-size: 13px !important;
+        padding: 0 8px !important;
+      }
+
+      .save-btn-container-tb .v-btn .v-icon {
+        font-size: 17px !important;
+      }
+
+      /* ボタン間隔もPC用の20pxから縮小後のサイズに合わせて詰める */
+      .save-btn-container-tb .v-btn+.v-btn {
+        margin-left: 10px !important;
+      }
+
+      /* NEWバッジの位置もサイドバー下部のボタン（デフォルト位置）に合わせる。
+         右へ32pxはみ出すタブレット用の位置のままだと、縮小したボタンから離れすぎて隣に重なる */
+      .save-btn-container-tb .new-badge {
+        right: -18px !important;
       }
 
       /* 席替え・コピペで入力・結果を復元を横1行に並べ、その下にリンク行を全幅で置く。
@@ -743,6 +775,119 @@
     .v-card__title.teal.lighten-2 {
       background-color: #0c9ea8 !important;
     }
+
+    /* ===== 印刷機能 ===== */
+    /* 印刷専用レイアウトは画面には一切表示しない（印刷時のみ表示される） */
+    #print-area {
+      display: none;
+    }
+
+    @media print {
+
+      /* アプリ画面全体を隠し、印刷専用レイアウトだけを印刷する */
+      .v-application {
+        display: none !important;
+      }
+
+      /* 座席表は横長になりやすいためA4横向きで印刷する。
+         余白を0にすると、ブラウザがヘッダー・フッターとして印字する
+         ページタイトル（席替えメーカー…）やURL・日付が消える。
+         紙端の余白は代わりに.print-pageのpaddingで確保する */
+      @page {
+        size: A4 landscape;
+        margin: 0;
+      }
+
+      #print-area {
+        display: block;
+        text-align: center;
+        font-family: 'Roboto', 'Noto Sans JP', sans-serif;
+        color: #000000;
+        /* プリンタの「背景を印刷しない」設定でも性別の座席色を出力する */
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+      }
+
+      /* 1ページ＝1枚の座席表。@pageのmargin 0の代わりにここで紙端の余白を確保する */
+      .print-page {
+        padding: 10mm 10mm 0;
+      }
+
+      .print-page:not(:last-of-type) {
+        page-break-after: always;
+      }
+
+      .print-title {
+        font-size: 20pt;
+        font-weight: 900;
+        margin-bottom: 5mm;
+      }
+
+      /* 教室の向きが分かるように、最前列側に黒板を表示する */
+      .print-blackboard {
+        width: 60%;
+        margin: 0 auto 7mm;
+        padding: 1.5mm 0;
+        border: 0.5mm solid #333333;
+        border-radius: 1.5mm;
+        font-size: 12pt;
+        font-weight: 700;
+        letter-spacing: 3mm;
+        text-indent: 3mm; /* letter-spacingで最後の文字の右に付く余白を相殺して中央に見せる */
+      }
+
+      /* 教壇側から見た図（2ページ目）では最前列が下端に来るため、黒板も下端に表示する */
+      .print-blackboard-bottom {
+        margin: 7mm auto 0;
+      }
+
+      /* ページ右下の小さなクレジット。position: fixedのため印刷時は全ページに入る */
+      .print-credit {
+        position: fixed;
+        bottom: 5mm;
+        right: 7mm;
+        font-size: 8pt;
+        color: #888888;
+      }
+
+      .print-row {
+        white-space: nowrap;
+      }
+
+      .print-seat {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+        /* 列数・行数が多いときも1ページに収まるように自動で縮める */
+        width: min(30mm, calc(240mm / var(--print-cols, 6)));
+        height: min(14mm, calc(140mm / var(--print-rows, 6)));
+        margin: 0.8mm;
+        border: 0.5mm solid #333333;
+        border-radius: 1.5mm;
+        font-size: 12pt;
+        font-weight: 600;
+        overflow: hidden;
+      }
+
+      /* 班の区切り（画面のmargin-right・margin-bottomに対応） */
+      .print-group-gap-right {
+        margin-right: 4mm;
+      }
+
+      .print-group-gap-bottom {
+        height: 4mm;
+      }
+
+      /* 班長の星マーク（画面のmdi-starに対応） */
+      .print-leader-star {
+        position: absolute;
+        top: 0;
+        left: 1mm;
+        font-size: 9pt;
+        color: #F9A825;
+      }
+    }
   </style>
 </head>
 
@@ -782,9 +927,14 @@
         </header>
         <div class="pc-only save-btn-container">
           <v-btn elevation="2" x-large color="#0c9ea8" dark @click="openSaveDialog()"
-            style="font-size: 20px; font-weight: 900; margin-right: 80px;">
+            style="font-size: 20px; font-weight: 900;">
             <span class="new-badge" style="right: -32px;">NEW</span>
             <v-icon left>mdi-content-save</v-icon>結果を保存
+          </v-btn>
+          <v-btn elevation="2" x-large color="#0c9ea8" dark @click="printSeats()"
+            style="font-size: 20px; font-weight: 900; margin-left: 20px; margin-right: 80px;">
+            <span class="new-badge" style="right: -32px;">NEW</span>
+            <v-icon left>mdi-printer</v-icon>印刷
           </v-btn>
         </div>
 
@@ -1200,7 +1350,8 @@
                             2026.06.08　席替え結果を名前を付けて保存・復元できるようになりました。<br>
                             2026.06.10　一度入力した条件を削除できるようになりました。<br>
                             2026.07.08　席替えボタンを画面下部に固定しました。<br>
-                            2026.07.08　スマホに対応しました。
+                            2026.07.08　スマホに対応しました。<br>
+                            2026.07.21　席替え後の座席表を印刷できるようになりました。
                           </v-card-text>
                         </v-card>
                       </v-dialog>
@@ -1361,6 +1512,11 @@
             <span class="new-badge" style="right: -32px;">NEW</span>
             <v-icon left>mdi-content-save</v-icon>結果を保存
           </v-btn>
+          <v-btn elevation="2" x-large color="#0c9ea8" dark @click="printSeats()"
+            style="font-size: 20px; font-weight: 900; margin-left: 20px;">
+            <span class="new-badge" style="right: -32px;">NEW</span>
+            <v-icon left>mdi-printer</v-icon>印刷
+          </v-btn>
         </div>
         <div class="tb-only"></div><!-- グリッドレイアウト調整用 -->
 
@@ -1439,6 +1595,18 @@
           </v-card>
         </v-dialog>
 
+        <!-- 印刷時の席替え結果未生成エラー -->
+        <v-dialog v-model="printEmptyError" width="500">
+          <v-card>
+            <v-card-title class="headline grey lighten-2 font-weight-black" style="display: inherit;">エラー
+              <v-icon style="float: right;" @click="printEmptyError = false">mdi-close</v-icon>
+            </v-card-title>
+            <v-card-text style="margin-top: 20px; color: #000000;" class="font-weight-regular">
+              席替えを行ってから印刷ボタンを押してください。
+            </v-card-text>
+          </v-card>
+        </v-dialog>
+
         <!-- Excelペーストダイアログ -->
         <v-dialog v-model="isShowStudentsNameDialog" width="550">
           <v-card>
@@ -1481,6 +1649,17 @@
             <v-card-text style="margin-top: 20px; color: #5a5a5a; font-size: 16px; font-weight: 600;">
               <div style="margin-bottom: 20px;">
                 <div style="margin-bottom: 8px;">
+                  <span style="font-size: 14px; color: #999;">2026.07.21</span>
+                </div>
+                <div style="font-size: 18px; font-weight: 700; margin-bottom: 8px;">
+                  席替え結果を印刷できるようになりました！
+                </div>
+                <div style="font-size: 14px;">
+                  印刷ボタンを押すと、生徒側から見た座席表と教壇側から見た座席表をまとめて印刷できます。PDFとして保存することもできます。
+                </div>
+              </div>
+              <div>
+                <div style="margin-bottom: 8px;">
                   <span style="font-size: 14px; color: #999;">2026.06.10</span>
                 </div>
                 <div style="font-size: 18px; font-weight: 700; margin-bottom: 8px;">
@@ -1488,17 +1667,6 @@
                 </div>
                 <div style="font-size: 14px;">
                   入力した条件の右側に表示される削除ボタンを押すことで、条件を個別に削除できるようになりました。
-                </div>
-              </div>
-              <div>
-                <div style="margin-bottom: 8px;">
-                  <span style="font-size: 14px; color: #999;">2026.06.08</span>
-                </div>
-                <div style="font-size: 18px; font-weight: 700; margin-bottom: 8px;">
-                  席替え結果を名前を付けて保存できるようになりました！
-                </div>
-                <div style="font-size: 14px;">
-                  席替えの結果を好きな名前で保存し、同一デバイスでいつでも復元できるようになりました。
                 </div>
               </div>
             </v-card-text>
@@ -1595,6 +1763,51 @@
         </v-dialog>
       </div>
     </v-app>
+
+    <!-- 印刷専用の座席表レイアウト。画面には表示されず、印刷時のみ表示される（CSSの#print-area参照）。
+         Vuetifyのコンポーネントはv-appの外では動かないため、素のHTMLで組む -->
+    <div id="print-area" aria-hidden="true"
+      :style="{ '--print-cols': String(seatsSizeX), '--print-rows': String(seatsSizeY) }">
+      <!-- 1ページ目: 生徒側から見た図。最前列（nextSeatsTableの0行目）が上端なので、上端に黒板を表示する -->
+      <section class="print-page">
+        <div class="print-title">生徒側から見た座席表</div>
+        <div class="print-blackboard">黒板</div>
+        <template v-for="( printSeatsRow, printIndexRow ) in nextSeatsTable">
+          <div class="print-row" :key="'printRow' + printIndexRow">
+            <span v-for="( printSeat, printIndexCol ) in printSeatsRow" class="print-seat"
+              :class="[getColorByNextSeat(printSeat, printIndexCol, printIndexRow),
+                       {'print-group-gap-right': (printIndexCol+1)%groupSizeX==0 && (printIndexCol+1)!=seatsSizeX}]"
+              :key="'printSeat' + printIndexRow + '-' + printIndexCol">
+              <span v-if="printSeat && leaderConditions.includes(printSeat)" class="print-leader-star">★</span>
+              {{ printSeat }}
+            </span>
+          </div>
+          <div v-if="(printIndexRow+1)%groupSizeY==0 && (printIndexRow+1)!=seatsSizeY" class="print-group-gap-bottom"
+            :key="'printGap' + printIndexRow"></div>
+        </template>
+      </section>
+      <!-- 2ページ目: 教壇側から見た図。1ページ目を180度回転した配置（printTeacherViewTable）で、
+           最前列が下端に来るため黒板も下端に表示する -->
+      <section class="print-page">
+        <div class="print-title">教壇側から見た座席表</div>
+        <template v-for="( printSeatsRow2, printIndexRow2 ) in printTeacherViewTable">
+          <div class="print-row" :key="'printRowT' + printIndexRow2">
+            <span v-for="printCell in printSeatsRow2" class="print-seat"
+              :class="[getColorByNextSeat(printCell.name, printCell.col, printCell.row),
+                       {'print-group-gap-right': printCell.col%groupSizeX==0 && printCell.col!=0}]"
+              :key="'printSeatT' + printCell.row + '-' + printCell.col">
+              <span v-if="printCell.name && leaderConditions.includes(printCell.name)" class="print-leader-star">★</span>
+              {{ printCell.name }}
+            </span>
+          </div>
+          <div v-if="printSeatsRow2[0].row%groupSizeY==0 && printSeatsRow2[0].row!=0" class="print-group-gap-bottom"
+            :key="'printGapT' + printIndexRow2"></div>
+        </template>
+        <div class="print-blackboard print-blackboard-bottom">黒板</div>
+      </section>
+      <!-- ページ右下の小さなクレジット -->
+      <div class="print-credit">©席替えメーカー</div>
+    </div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/vue@2.7.16/dist/vue.min.js"></script>
@@ -1705,6 +1918,7 @@
         saveNameError: '', // 保存名のエラーメッセージ
         isShowOverwriteConfirm: false, // 上書き確認の表示制御フラグ
         overwriteTargetName: '', // 上書き対象の保存名
+        printEmptyError: false, // 席替え結果がない状態で印刷ボタンが押されたときのエラー表示制御フラグ
       },
       methods: {
         startTutorial() {
@@ -2645,6 +2859,14 @@
           const list = JSON.parse(localStorage.getItem('sekigae_saved_list'));
           return list || [];
         },
+        printSeats() { // 席替え後の座席表を印刷する（印刷内容は#print-areaで組み立てる）
+          const hasResult = this.nextSeatsTable.some(seatsRow => seatsRow.some(seat => seat !== ''));
+          if (!hasResult) {
+            this.printEmptyError = true; // 席替え結果がまだ無いときはエラーを表示
+            return;
+          }
+          window.print();
+        },
         openSaveDialog() { // 保存ダイアログを開く
           this.saveName = '';
           this.saveNameError = '';
@@ -2807,7 +3029,7 @@
         window.addEventListener('resize', this.onResize);
 
         // 新機能モーダルの表示判定
-        const newFeatureKey = 'newFeatureModal_v3';
+        const newFeatureKey = 'newFeatureModal_v4';
         if (!localStorage.getItem(newFeatureKey)) {
           // ランディングモーダルが閉じられた後に表示する
           const unwatch = this.$watch('landing', (newVal) => {
@@ -3044,6 +3266,20 @@
           return this.excelPasteText
             .split(/[\s\u3000]+/)
             .filter(function (name) { return name !== ''; });
+        },
+        printTeacherViewTable() { // \u5370\u52372\u30da\u30fc\u30b8\u76ee\u7528\u3002\u6559\u58c7\u5074\u304b\u3089\u898b\u305f\u5ea7\u5e2d\u8868\uff1dnextSeatsTable\u3092180\u5ea6\u56de\u8ee2\uff08\u884c\u30fb\u5217\u3068\u3082\u9006\u9806\uff09\u3057\u305f\u914d\u7f6e\u3002
+          // col/row\u306b\u306f\u5143\u30c6\u30fc\u30d6\u30eb\u306e\u5ea7\u6a19\u3092\u6b8b\u3057\u3001\u6027\u5225\u8272\u306e\u5224\u5b9a\uff08getColorByNextSeat\uff09\u3068\u73ed\u306e\u533a\u5207\u308a\u306e\u8a08\u7b97\u306b\u4f7f\u3046\u3002
+          // \u73ed\u306e\u533a\u5207\u308a\u306f1\u30da\u30fc\u30b8\u76ee\u306e\u300c(index+1)%groupSize==0\u304b\u3064\u672b\u5c3e\u4ee5\u5916\u300d\u306e\u93e1\u6620\u3057\u3067\u3001
+          // \u5143\u306e\u5ea7\u6a19\u3067\u306f\u300cindex%groupSize==0\u304b\u3064\u5148\u982d\u4ee5\u5916\u300d\u306e\u30bb\u30eb\u306e\u5f8c\u308d\u306b\u6765\u308b
+          const rows = [];
+          for (let row = this.seatsSizeY - 1; row >= 0; row--) {
+            const cells = [];
+            for (let col = this.seatsSizeX - 1; col >= 0; col--) {
+              cells.push({ name: this.nextSeatsTable[row][col], col: col, row: row });
+            }
+            rows.push(cells);
+          }
+          return rows;
         }
       }
     });

--- a/index.html
+++ b/index.html
@@ -182,19 +182,33 @@
         margin-left: 0 !important;
       }
 
+      /* スマホでは各所のボタン（一括入力・使い方/デモデータ・席替え/コピペ/復元・保存/印刷）を
+         共通のコンパクトサイズに統一する（インラインstyleやVuetifyのサイズ指定に勝つため!important）。
+         margin・paddingは配置の都合が異なるため各ボタンのルールで個別に指定する */
+      .bulk-input-btn,
+      .v-navigation-drawer .sidebar-top-btn,
+      .sidebar-bottom-sticky .v-btn,
+      .save-btn-container-tb .v-btn {
+        height: 34px !important;
+        font-size: 13px !important;
+      }
+
+      .v-navigation-drawer .sidebar-top-btn .v-icon,
+      .sidebar-bottom-sticky .v-btn .v-icon,
+      .save-btn-container-tb .v-btn .v-icon {
+        font-size: 17px !important;
+      }
+
       /* 絶対配置のままだと画面外にはみ出すため、タイトル横の通常フローに戻す。
          staticではなくrelativeにするのは、子のNEWバッジ（絶対配置）の基準を
          このボタンのまま保つため（staticだと基準が外側のタイトルspanに変わってずれる）。
-         relativeはインラインのleft/topをオフセットとして適用してしまうため、両方打ち消す。
-         大きさはサイドバー下部のボタンと同じに縮小する */
+         relativeはインラインのleft/topをオフセットとして適用してしまうため、両方打ち消す */
       .bulk-input-btn {
         position: relative !important;
         left: 0 !important;
         top: 0 !important;
         transform: none !important;
         margin-left: 10px !important;
-        height: 34px !important;
-        font-size: 13px !important;
         padding: 0 8px !important;
       }
 
@@ -248,17 +262,11 @@
         font-size: 30px !important;
       }
 
-      /* 使い方・デモデータボタンを縮小する（インラインstyleに勝つため!important）。
-         マイナスマージンはPC用の大きいタイトルに合わせた値のため、縮小後の高さに合わせて調整する */
+      /* 使い方・デモデータボタンのマイナスマージンはPC用の大きいタイトルに合わせた値のため、
+         縮小後の高さに合わせて調整する */
       .v-navigation-drawer .sidebar-top-btn {
-        height: 34px !important;
-        font-size: 13px !important;
         margin: -8px 0 0 6px !important;
         padding: 0 8px !important;
-      }
-
-      .v-navigation-drawer .sidebar-top-btn .v-icon {
-        font-size: 17px !important;
       }
 
       .v-navigation-drawer .sidebar-top-btn .icon {
@@ -296,32 +304,18 @@
         font-size: 14px;
       }
 
-      /* 席替え・コピペで入力・結果を復元の3ボタンを1行に収めるためコンパクトに縮小する
-         （使い方ボタンと同じ大きさ。狭い画面でも折り返さないよう間隔・余白も詰める） */
+      /* 席替え・コピペで入力・結果を復元の3ボタンを1行に収めるため、
+         狭い画面でも折り返さないよう間隔・余白を詰める */
       .sidebar-bottom-sticky .v-btn {
-        height: 34px !important;
-        font-size: 13px !important;
         margin: 4px 10px 4px 0 !important;
         padding: 0 5px !important;
       }
 
-      .sidebar-bottom-sticky .v-btn .v-icon {
-        font-size: 17px !important;
-      }
-
-      /* 結果を保存・印刷ボタンも、サイドバー下部のボタンと同じ大きさに縮小する
-         （インラインstyleに勝つため!important） */
       .save-btn-container-tb .v-btn {
-        height: 34px !important;
-        font-size: 13px !important;
         padding: 0 8px !important;
       }
 
-      .save-btn-container-tb .v-btn .v-icon {
-        font-size: 17px !important;
-      }
-
-      /* ボタン間隔もPC用の20pxから縮小後のサイズに合わせて詰める */
+      /* 結果を保存・印刷のボタン間隔もPC用の20pxから縮小後のサイズに合わせて詰める */
       .save-btn-container-tb .v-btn+.v-btn {
         margin-left: 10px !important;
       }
@@ -841,13 +835,25 @@
         margin: 7mm auto 0;
       }
 
-      /* ページ右下の小さなクレジット。position: fixedのため印刷時は全ページに入る */
+      /* ページ右下の小さなクレジット。position: fixedのため印刷時は全ページに入る。
+         @pageのmargin 0によりプリンタの印刷不可領域（紙端4〜6mm程度）に掛かると欠けるため、
+         .print-pageのpaddingと同じ10mmだけ紙端から離す */
       .print-credit {
         position: fixed;
-        bottom: 5mm;
-        right: 7mm;
+        bottom: 10mm;
+        right: 10mm;
         font-size: 8pt;
         color: #888888;
+      }
+
+      /* チュートリアル表示中に印刷しても、body直下（.v-applicationの外）に追加される
+         intro.jsのオーバーレイ・吹き出しが座席表に重ならないようにする */
+      .introjs-overlay,
+      .introjs-helperLayer,
+      .introjs-tooltipReferenceLayer,
+      .introjs-tooltip,
+      .introjs-hints {
+        display: none !important;
       }
 
       .print-row {
@@ -859,9 +865,11 @@
         align-items: center;
         justify-content: center;
         position: relative;
-        /* 列数・行数が多いときも1ページに収まるように自動で縮める */
+        /* 列数・行数が多いときも1ページに収まるように自動で縮める。
+           高さは1行あたりの上下margin（1.6mm）を差し引き、タイトル・黒板・班間ギャップ
+           （最悪ケース：12行・班縦2で20mm）を見込んだ145mmを予算にする */
         width: min(30mm, calc(240mm / var(--print-cols, 6)));
-        height: min(14mm, calc(140mm / var(--print-rows, 6)));
+        height: min(14mm, calc(145mm / var(--print-rows, 6) - 1.6mm));
         margin: 0.8mm;
         border: 0.5mm solid #333333;
         border-radius: 1.5mm;
@@ -1550,9 +1558,7 @@
                           :aria-label="'席替え後 ' + (nextIndexRow+1) + '行' + (nextIndexCol+1) + '列'"
                           style="text-align: center;  resize: none; word-break: keep-all; vertical-align: top; font-size: 22px; font-weight: 600;"
                           :value="nextSeatsTable[nextIndexRow][nextIndexCol]">
-                        <v-icon
-                          v-if="nextSeatsTable[nextIndexRow][nextIndexCol] && leaderConditions.includes(nextSeatsTable[nextIndexRow][nextIndexCol])"
-                          color="#F9A825"
+                        <v-icon v-if="isLeader(nextSeatsTable[nextIndexRow][nextIndexCol])" color="#F9A825"
                           style="position: absolute; top: 4px; left: 4px; font-size: 24px; pointer-events: none;">mdi-star</v-icon>
                       </div>
                     </span>
@@ -1595,14 +1601,14 @@
           </v-card>
         </v-dialog>
 
-        <!-- 印刷時の席替え結果未生成エラー -->
+        <!-- 印刷時の座席未入力エラー -->
         <v-dialog v-model="printEmptyError" width="500">
           <v-card>
             <v-card-title class="headline grey lighten-2 font-weight-black" style="display: inherit;">エラー
               <v-icon style="float: right;" @click="printEmptyError = false">mdi-close</v-icon>
             </v-card-title>
             <v-card-text style="margin-top: 20px; color: #000000;" class="font-weight-regular">
-              席替えを行ってから印刷ボタンを押してください。
+              座席に生徒の名前を入力してから印刷ボタンを押してください。
             </v-card-text>
           </v-card>
         </v-dialog>
@@ -1765,20 +1771,21 @@
     </v-app>
 
     <!-- 印刷専用の座席表レイアウト。画面には表示されず、印刷時のみ表示される（CSSの#print-area参照）。
+         印刷元はprintSourceTable（席替え結果、なければ今の座席）。
          Vuetifyのコンポーネントはv-appの外では動かないため、素のHTMLで組む -->
     <div id="print-area" aria-hidden="true"
       :style="{ '--print-cols': String(seatsSizeX), '--print-rows': String(seatsSizeY) }">
-      <!-- 1ページ目: 生徒側から見た図。最前列（nextSeatsTableの0行目）が上端なので、上端に黒板を表示する -->
+      <!-- 1ページ目: 生徒側から見た図。最前列（テーブルの0行目）が上端なので、上端に黒板を表示する -->
       <section class="print-page">
         <div class="print-title">生徒側から見た座席表</div>
         <div class="print-blackboard">黒板</div>
-        <template v-for="( printSeatsRow, printIndexRow ) in nextSeatsTable">
+        <template v-for="( printSeatsRow, printIndexRow ) in printSourceTable">
           <div class="print-row" :key="'printRow' + printIndexRow">
             <span v-for="( printSeat, printIndexCol ) in printSeatsRow" class="print-seat"
-              :class="[getColorByNextSeat(printSeat, printIndexCol, printIndexRow),
+              :class="[getColorByPrintSeat(printSeat, printIndexCol, printIndexRow),
                        {'print-group-gap-right': (printIndexCol+1)%groupSizeX==0 && (printIndexCol+1)!=seatsSizeX}]"
               :key="'printSeat' + printIndexRow + '-' + printIndexCol">
-              <span v-if="printSeat && leaderConditions.includes(printSeat)" class="print-leader-star">★</span>
+              <span v-if="isLeader(printSeat)" class="print-leader-star">★</span>
               {{ printSeat }}
             </span>
           </div>
@@ -1790,18 +1797,17 @@
            最前列が下端に来るため黒板も下端に表示する -->
       <section class="print-page">
         <div class="print-title">教壇側から見た座席表</div>
-        <template v-for="( printSeatsRow2, printIndexRow2 ) in printTeacherViewTable">
+        <template v-for="( printRow2, printIndexRow2 ) in printTeacherViewTable">
           <div class="print-row" :key="'printRowT' + printIndexRow2">
-            <span v-for="printCell in printSeatsRow2" class="print-seat"
-              :class="[getColorByNextSeat(printCell.name, printCell.col, printCell.row),
-                       {'print-group-gap-right': printCell.col%groupSizeX==0 && printCell.col!=0}]"
+            <span v-for="printCell in printRow2.cells" class="print-seat"
+              :class="[getColorByPrintSeat(printCell.name, printCell.col, printCell.row),
+                       {'print-group-gap-right': printCell.gapRight}]"
               :key="'printSeatT' + printCell.row + '-' + printCell.col">
-              <span v-if="printCell.name && leaderConditions.includes(printCell.name)" class="print-leader-star">★</span>
+              <span v-if="isLeader(printCell.name)" class="print-leader-star">★</span>
               {{ printCell.name }}
             </span>
           </div>
-          <div v-if="printSeatsRow2[0].row%groupSizeY==0 && printSeatsRow2[0].row!=0" class="print-group-gap-bottom"
-            :key="'printGapT' + printIndexRow2"></div>
+          <div v-if="printRow2.gapBelow" class="print-group-gap-bottom" :key="'printGapT' + printIndexRow2"></div>
         </template>
         <div class="print-blackboard print-blackboard-bottom">黒板</div>
       </section>
@@ -2192,6 +2198,23 @@
           } else {
             return 'off-seats'
           }
+        },
+        getColorByPrintSeat(name, col, row) { // 印刷用の座席色を返す。印刷元がどちらのテーブルかで判定を切り替える
+          if (!this.hasNextSeatsResult) {
+            // 今の座席を印刷するとき：座席の性別はgenderTableの座標そのもの（デモ用の空席色は印刷しない）
+            const gender = name === '' ? '' : this.genderTable[row][col];
+            if (gender === 'male') {
+              return 'male-seats'
+            } else if (gender === 'female') {
+              return 'female-seats'
+            } else {
+              return 'off-seats'
+            }
+          }
+          return this.getColorByNextSeat(name, col, row);
+        },
+        isLeader(name) { // その生徒が班長かどうか。画面と印刷の両方の星表示で使う
+          return name !== '' && this.leaderConditions.includes(name);
         },
         toggleGender(col, row) {
           if (this.genderTable[row][col] === 'male') {
@@ -2859,13 +2882,18 @@
           const list = JSON.parse(localStorage.getItem('sekigae_saved_list'));
           return list || [];
         },
-        printSeats() { // 席替え後の座席表を印刷する（印刷内容は#print-areaで組み立てる）
-          const hasResult = this.nextSeatsTable.some(seatsRow => seatsRow.some(seat => seat !== ''));
-          if (!hasResult) {
-            this.printEmptyError = true; // 席替え結果がまだ無いときはエラーを表示
+        printSeats() { // 座席表を印刷する（印刷内容は#print-areaで組み立てる）
+          const hasStudents = this.printSourceTable.some(seatsRow => seatsRow.some(seat => seat !== ''));
+          if (!hasStudents) {
+            this.printEmptyError = true; // 印刷できる座席表がまだ無いときはエラーを表示
             return;
           }
-          window.print();
+          // ドラッグでの手動調整はDOMだけが入れ替わりnextSeatsTableには未反映のため、
+          // 席替えボタンと同じ同期処理を通してから印刷する（未調整なら何もしない）
+          this.beforeChangeSeats();
+          this.$nextTick(function () { // 同期した内容が#print-areaに描画されるのを待ってから印刷する
+            window.print();
+          });
         },
         openSaveDialog() { // 保存ダイアログを開く
           this.saveName = '';
@@ -3267,17 +3295,29 @@
             .split(/[\s\u3000]+/)
             .filter(function (name) { return name !== ''; });
         },
-        printTeacherViewTable() { // \u5370\u52372\u30da\u30fc\u30b8\u76ee\u7528\u3002\u6559\u58c7\u5074\u304b\u3089\u898b\u305f\u5ea7\u5e2d\u8868\uff1dnextSeatsTable\u3092180\u5ea6\u56de\u8ee2\uff08\u884c\u30fb\u5217\u3068\u3082\u9006\u9806\uff09\u3057\u305f\u914d\u7f6e\u3002
-          // col/row\u306b\u306f\u5143\u30c6\u30fc\u30d6\u30eb\u306e\u5ea7\u6a19\u3092\u6b8b\u3057\u3001\u6027\u5225\u8272\u306e\u5224\u5b9a\uff08getColorByNextSeat\uff09\u3068\u73ed\u306e\u533a\u5207\u308a\u306e\u8a08\u7b97\u306b\u4f7f\u3046\u3002
+        hasNextSeatsResult() { // \u5e2d\u66ff\u3048\u7d50\u679c\u304c\u5b58\u5728\u3059\u308b\u304b\u3069\u3046\u304b\u3002\u5e2d\u66ff\u3048\u524d\u30fb\u5fa9\u5143\u76f4\u5f8c\u30fb\u5ea7\u5e2d\u6570\u5909\u66f4\u76f4\u5f8c\u306ffalse
+          return this.nextSeatsTable.some(seatsRow => seatsRow.some(seat => seat !== ''));
+        },
+        printSourceTable() { // \u5370\u5237\u3059\u308b\u5ea7\u5e2d\u8868\u3002\u5e2d\u66ff\u3048\u7d50\u679c\u304c\u3042\u308c\u3070\u305d\u308c\u3092\u3001\u306a\u3051\u308c\u3070\u4eca\u306e\u5ea7\u5e2d\uff08\u5fa9\u5143\u76f4\u5f8c\u3084\u5e2d\u66ff\u3048\u524d\uff09\u3092\u5370\u5237\u3059\u308b
+          return this.hasNextSeatsResult ? this.nextSeatsTable : this.seatsTable;
+        },
+        printTeacherViewTable() { // \u5370\u52372\u30da\u30fc\u30b8\u76ee\u7528\u3002\u6559\u58c7\u5074\u304b\u3089\u898b\u305f\u5ea7\u5e2d\u8868\uff1dprintSourceTable\u3092180\u5ea6\u56de\u8ee2\uff08\u884c\u30fb\u5217\u3068\u3082\u9006\u9806\uff09\u3057\u305f\u914d\u7f6e\u3002
+          // col/row\u306b\u306f\u5143\u30c6\u30fc\u30d6\u30eb\u306e\u5ea7\u6a19\u3092\u6b8b\u3057\u3001\u6027\u5225\u8272\u306e\u5224\u5b9a\uff08getColorByPrintSeat\uff09\u306b\u4f7f\u3046\u3002
           // \u73ed\u306e\u533a\u5207\u308a\u306f1\u30da\u30fc\u30b8\u76ee\u306e\u300c(index+1)%groupSize==0\u304b\u3064\u672b\u5c3e\u4ee5\u5916\u300d\u306e\u93e1\u6620\u3057\u3067\u3001
-          // \u5143\u306e\u5ea7\u6a19\u3067\u306f\u300cindex%groupSize==0\u304b\u3064\u5148\u982d\u4ee5\u5916\u300d\u306e\u30bb\u30eb\u306e\u5f8c\u308d\u306b\u6765\u308b
+          // \u5143\u306e\u5ea7\u6a19\u3067\u306f\u300cindex%groupSize==0\u304b\u3064\u5148\u982d\u4ee5\u5916\u300d\u306e\u30bb\u30eb\u306e\u5f8c\u308d\u306b\u6765\u308b\uff08groupSize\u304c\u300c\u306a\u3057\u300d\u306e\u3068\u304d\u306f\u5e38\u306bfalse\uff09
+          const sourceTable = this.printSourceTable;
           const rows = [];
           for (let row = this.seatsSizeY - 1; row >= 0; row--) {
             const cells = [];
             for (let col = this.seatsSizeX - 1; col >= 0; col--) {
-              cells.push({ name: this.nextSeatsTable[row][col], col: col, row: row });
+              cells.push({
+                name: sourceTable[row][col],
+                col: col,
+                row: row,
+                gapRight: col % this.groupSizeX === 0 && col !== 0,
+              });
             }
-            rows.push(cells);
+            rows.push({ cells: cells, gapBelow: row % this.groupSizeY === 0 && row !== 0 });
           }
           return rows;
         }

--- a/index.html
+++ b/index.html
@@ -2967,6 +2967,9 @@
             return;
           }
           const data = JSON.parse(dataStr);
+          // 座席数が変わらない復元ではwatcher経由のmakeNextSeatsTable()が走らないため、
+          // 復元前のドラッグ未反映キューが残って復元結果に適用されないよう、ここで破棄する
+          this.clearPendingSwaps();
           this.seatsTable = data.seatsTable;
           this.genderTable = data.genderTable;
           this.seatsSizeY = data.seatsSizeY;

--- a/index.html
+++ b/index.html
@@ -1601,14 +1601,14 @@
           </v-card>
         </v-dialog>
 
-        <!-- 印刷時の座席未入力エラー -->
+        <!-- 印刷時の席替え結果未生成エラー -->
         <v-dialog v-model="printEmptyError" width="500">
           <v-card>
             <v-card-title class="headline grey lighten-2 font-weight-black" style="display: inherit;">エラー
               <v-icon style="float: right;" @click="printEmptyError = false">mdi-close</v-icon>
             </v-card-title>
             <v-card-text style="margin-top: 20px; color: #000000;" class="font-weight-regular">
-              座席に生徒の名前を入力してから印刷ボタンを押してください。
+              席替えを行ってから印刷ボタンを押してください。
             </v-card-text>
           </v-card>
         </v-dialog>
@@ -1771,7 +1771,7 @@
     </v-app>
 
     <!-- 印刷専用の座席表レイアウト。画面には表示されず、印刷時のみ表示される（CSSの#print-area参照）。
-         印刷元はprintSourceTable（席替え結果、なければ今の座席）。
+         印刷元はnextSeatsTable（席替え後の座席表）。
          Vuetifyのコンポーネントはv-appの外では動かないため、素のHTMLで組む -->
     <div id="print-area" aria-hidden="true"
       :style="{ '--print-cols': String(seatsSizeX), '--print-rows': String(seatsSizeY) }">
@@ -1779,10 +1779,10 @@
       <section class="print-page">
         <div class="print-title">生徒側から見た座席表</div>
         <div class="print-blackboard">黒板</div>
-        <template v-for="( printSeatsRow, printIndexRow ) in printSourceTable">
+        <template v-for="( printSeatsRow, printIndexRow ) in nextSeatsTable">
           <div class="print-row" :key="'printRow' + printIndexRow">
             <span v-for="( printSeat, printIndexCol ) in printSeatsRow" class="print-seat"
-              :class="[getColorByPrintSeat(printSeat, printIndexCol, printIndexRow),
+              :class="[getColorByNextSeat(printSeat, printIndexCol, printIndexRow),
                        {'print-group-gap-right': (printIndexCol+1)%groupSizeX==0 && (printIndexCol+1)!=seatsSizeX}]"
               :key="'printSeat' + printIndexRow + '-' + printIndexCol">
               <span v-if="isLeader(printSeat)" class="print-leader-star">★</span>
@@ -1800,7 +1800,7 @@
         <template v-for="( printRow2, printIndexRow2 ) in printTeacherViewTable">
           <div class="print-row" :key="'printRowT' + printIndexRow2">
             <span v-for="printCell in printRow2.cells" class="print-seat"
-              :class="[getColorByPrintSeat(printCell.name, printCell.col, printCell.row),
+              :class="[getColorByNextSeat(printCell.name, printCell.col, printCell.row),
                        {'print-group-gap-right': printCell.gapRight}]"
               :key="'printSeatT' + printCell.row + '-' + printCell.col">
               <span v-if="isLeader(printCell.name)" class="print-leader-star">★</span>
@@ -2199,20 +2199,6 @@
             return 'off-seats'
           }
         },
-        getColorByPrintSeat(name, col, row) { // 印刷用の座席色を返す。印刷元がどちらのテーブルかで判定を切り替える
-          if (!this.hasNextSeatsResult) {
-            // 今の座席を印刷するとき：座席の性別はgenderTableの座標そのもの（デモ用の空席色は印刷しない）
-            const gender = name === '' ? '' : this.genderTable[row][col];
-            if (gender === 'male') {
-              return 'male-seats'
-            } else if (gender === 'female') {
-              return 'female-seats'
-            } else {
-              return 'off-seats'
-            }
-          }
-          return this.getColorByNextSeat(name, col, row);
-        },
         isLeader(name) { // その生徒が班長かどうか。画面と印刷の両方の星表示で使う
           return name !== '' && this.leaderConditions.includes(name);
         },
@@ -2258,7 +2244,17 @@
           }
           this.countSeats();
         },
+        clearPendingSwaps() { // ドラッグ調整の未反映キューを破棄する。
+          // 座席テーブルを作り直すとキュー内の座標が新しいテーブルの範囲外になり得るため、
+          // そのままreverseSeats()が走ると範囲外参照でクラッシュする
+          fromRows.splice(0);
+          fromCols.splice(0);
+          toRows.splice(0);
+          toCols.splice(0);
+          isReverseSeats = false;
+        },
         makeNextSeatsTable() { // nextSeatsTableを作成
+          this.clearPendingSwaps(); // 作り直し前の座標を指すドラッグ未反映キューを無効化
           this.nextSeatsTable.splice(0)
           for (let i = 0; i < this.seatsSizeY; i++) {
             this.nextSeatsTable.push(Array(this.seatsSizeX).fill('')) // すべての席に名前が未入力な状態でテーブルを作成
@@ -2882,17 +2878,30 @@
           const list = JSON.parse(localStorage.getItem('sekigae_saved_list'));
           return list || [];
         },
-        printSeats() { // 座席表を印刷する（印刷内容は#print-areaで組み立てる）
-          const hasStudents = this.printSourceTable.some(seatsRow => seatsRow.some(seat => seat !== ''));
-          if (!hasStudents) {
-            this.printEmptyError = true; // 印刷できる座席表がまだ無いときはエラーを表示
+        printSeats() { // 席替え後の座席表を印刷する（印刷内容は#print-areaで組み立てる）
+          if (!this.hasNextSeatsResult) {
+            this.printEmptyError = true; // 席替え結果がまだ無いときはエラーを表示
             return;
           }
           // ドラッグでの手動調整はDOMだけが入れ替わりnextSeatsTableには未反映のため、
-          // 席替えボタンと同じ同期処理を通してから印刷する（未調整なら何もしない）
+          // 席替えボタンと同じ同期処理（データ反映＋再描画）を通してから印刷する。
+          // beforeChangeSeats()がフラグを消すため、調整があったかどうかは先に控えておく
+          const hasPendingSwaps = isReverseSeats;
           this.beforeChangeSeats();
-          this.$nextTick(function () { // 同期した内容が#print-areaに描画されるのを待ってから印刷する
-            window.print();
+          if (!hasPendingSwaps) {
+            window.print(); // 調整がなければ#print-areaは描画済みなのでそのまま印刷する
+            return;
+          }
+          // beforeChangeSeats()の再描画（isRenderNextSeatsTableのオフ→オン）が画面に反映されるのを
+          // 待ってから印刷する。1段目のnextTickでオンが予約され、2段目でその描画が完了する。
+          // これを待たないと、印刷ダイアログの背後で席替え後テーブルが空に見えてしまう
+          this.$nextTick(function () {
+            this.$nextTick(function () {
+              window.print();
+              // 再描画で座席のDOMが作り直されているため、席替えフロー（changeSeats）と同様に
+              // SortableJSを再セットする。これをしないと印刷後にドラッグできなくなる
+              setTimeout(this.setSortableJS, 100);
+            });
           });
         },
         openSaveDialog() { // 保存ダイアログを開く
@@ -2967,6 +2976,13 @@
           this.$nextTick(() => {
             this.groupSizeY = data.groupSizeY;
             this.groupSizeX = data.groupSizeX;
+            // 復元した結果を席替え後テーブルにも反映する。印刷と再保存は席替え後テーブルを
+            // 参照するため、ここに入れないと復元した結果を印刷・再保存できない。
+            // watcherのmakeNextSeatsTable()が空テーブルを作った後に上書きする必要があるので、
+            // 班サイズと同じくnextTickの中で行う（行はコピーして今の座席テーブルと切り離す）
+            for (let i = 0; i < data.seatsTable.length; i++) {
+              this.nextSeatsTable.splice(i, 1, data.seatsTable[i].slice());
+            }
           });
           // 条件は保存していないため、復元した座席と整合させるためデフォルトへリセットする
           this.nearConditions = [['', '', '']];
@@ -3295,17 +3311,14 @@
             .split(/[\s\u3000]+/)
             .filter(function (name) { return name !== ''; });
         },
-        hasNextSeatsResult() { // \u5e2d\u66ff\u3048\u7d50\u679c\u304c\u5b58\u5728\u3059\u308b\u304b\u3069\u3046\u304b\u3002\u5e2d\u66ff\u3048\u524d\u30fb\u5fa9\u5143\u76f4\u5f8c\u30fb\u5ea7\u5e2d\u6570\u5909\u66f4\u76f4\u5f8c\u306ffalse
+        hasNextSeatsResult() { // \u5e2d\u66ff\u3048\u7d50\u679c\u304c\u5b58\u5728\u3059\u308b\u304b\u3069\u3046\u304b\u3002\u5e2d\u66ff\u3048\u524d\u30fb\u5ea7\u5e2d\u6570\u5909\u66f4\u76f4\u5f8c\u306ffalse
           return this.nextSeatsTable.some(seatsRow => seatsRow.some(seat => seat !== ''));
         },
-        printSourceTable() { // \u5370\u5237\u3059\u308b\u5ea7\u5e2d\u8868\u3002\u5e2d\u66ff\u3048\u7d50\u679c\u304c\u3042\u308c\u3070\u305d\u308c\u3092\u3001\u306a\u3051\u308c\u3070\u4eca\u306e\u5ea7\u5e2d\uff08\u5fa9\u5143\u76f4\u5f8c\u3084\u5e2d\u66ff\u3048\u524d\uff09\u3092\u5370\u5237\u3059\u308b
-          return this.hasNextSeatsResult ? this.nextSeatsTable : this.seatsTable;
-        },
-        printTeacherViewTable() { // \u5370\u52372\u30da\u30fc\u30b8\u76ee\u7528\u3002\u6559\u58c7\u5074\u304b\u3089\u898b\u305f\u5ea7\u5e2d\u8868\uff1dprintSourceTable\u3092180\u5ea6\u56de\u8ee2\uff08\u884c\u30fb\u5217\u3068\u3082\u9006\u9806\uff09\u3057\u305f\u914d\u7f6e\u3002
-          // col/row\u306b\u306f\u5143\u30c6\u30fc\u30d6\u30eb\u306e\u5ea7\u6a19\u3092\u6b8b\u3057\u3001\u6027\u5225\u8272\u306e\u5224\u5b9a\uff08getColorByPrintSeat\uff09\u306b\u4f7f\u3046\u3002
+        printTeacherViewTable() { // \u5370\u52372\u30da\u30fc\u30b8\u76ee\u7528\u3002\u6559\u58c7\u5074\u304b\u3089\u898b\u305f\u5ea7\u5e2d\u8868\uff1dnextSeatsTable\u3092180\u5ea6\u56de\u8ee2\uff08\u884c\u30fb\u5217\u3068\u3082\u9006\u9806\uff09\u3057\u305f\u914d\u7f6e\u3002
+          // col/row\u306b\u306f\u5143\u30c6\u30fc\u30d6\u30eb\u306e\u5ea7\u6a19\u3092\u6b8b\u3057\u3001\u6027\u5225\u8272\u306e\u5224\u5b9a\uff08getColorByNextSeat\uff09\u306b\u4f7f\u3046\u3002
           // \u73ed\u306e\u533a\u5207\u308a\u306f1\u30da\u30fc\u30b8\u76ee\u306e\u300c(index+1)%groupSize==0\u304b\u3064\u672b\u5c3e\u4ee5\u5916\u300d\u306e\u93e1\u6620\u3057\u3067\u3001
           // \u5143\u306e\u5ea7\u6a19\u3067\u306f\u300cindex%groupSize==0\u304b\u3064\u5148\u982d\u4ee5\u5916\u300d\u306e\u30bb\u30eb\u306e\u5f8c\u308d\u306b\u6765\u308b\uff08groupSize\u304c\u300c\u306a\u3057\u300d\u306e\u3068\u304d\u306f\u5e38\u306bfalse\uff09
-          const sourceTable = this.printSourceTable;
+          const sourceTable = this.nextSeatsTable;
           const rows = [];
           for (let row = this.seatsSizeY - 1; row >= 0; row--) {
             const cells = [];

--- a/tests/print.spec.js
+++ b/tests/print.spec.js
@@ -3,6 +3,21 @@ const path = require('path');
 
 const INDEX_HTML = `file://${path.resolve(__dirname, '../index.html')}`;
 
+// 男女2名ずつ・性別を市松に配置したフィクスチャ。
+// 「男女の座席を固定」+「全員移動」のデフォルト条件でも、
+// 男子同士（A・D）と女子同士（B・C）の交換で条件を満たせる（エラーにならない）
+async function setupFourStudents(page) {
+  await page.evaluate(() => {
+    app.seatsTable.splice(0, 1, ['A', 'B', '', '', '', '']);
+    app.seatsTable.splice(1, 1, ['C', 'D', '', '', '', '']);
+    app.genderTable.splice(0, 1, ['male', 'female', '', '', '', '']);
+    app.genderTable.splice(1, 1, ['female', 'male', '', '', '', '']);
+    app.countSeats();
+    return null;
+  });
+  await page.waitForTimeout(150); // watcherでstudentsName/genderArrayが更新されるのを待つ
+}
+
 test.describe('印刷', () => {
 
   test.beforeEach(async ({ page }) => {
@@ -10,47 +25,42 @@ test.describe('印刷', () => {
     await page.evaluate(() => { localStorage.clear(); });
   });
 
-  test('席替え結果がない状態で印刷するとエラーが表示され、window.printは呼ばれない', async ({ page }) => {
-    const result = await page.evaluate(() => {
-      let printCalled = false;
-      window.print = () => { printCalled = true; }; // 実際の印刷ダイアログは開かせない
+  test('座席が空の状態で印刷するとエラーが表示され、window.printは呼ばれない', async ({ page }) => {
+    await page.evaluate(() => {
+      window.printCalled = false;
+      window.print = () => { window.printCalled = true; }; // 実際の印刷ダイアログは開かせない
       app.printSeats();
-      return { printCalled: printCalled, printEmptyError: app.printEmptyError };
+      return null;
+    });
+    await page.waitForTimeout(100); // printSeatsは$nextTick経由で印刷するため待つ
+    const result = await page.evaluate(() => {
+      return { printCalled: window.printCalled, printEmptyError: app.printEmptyError };
     });
     expect(result.printCalled).toBe(false);
     expect(result.printEmptyError).toBe(true);
   });
 
   test('席替え後に印刷するとwindow.printが呼ばれる', async ({ page }) => {
+    await setupFourStudents(page);
     await page.evaluate(() => {
-      app.seatsTable.splice(0, 1, ['A', 'B', '', '', '', '']);
-      app.genderTable.splice(0, 1, ['male', 'female', '', '', '', '']);
-      app.countSeats();
+      app.changeSeats();
+      window.printCalled = false;
+      window.print = () => { window.printCalled = true; }; // 実際の印刷ダイアログは開かせない
+      app.printSeats();
       return null;
     });
-    await page.waitForTimeout(150); // watcherでstudentsName/genderArrayが更新されるのを待つ
-
+    await page.waitForTimeout(100); // printSeatsは$nextTick経由で印刷するため待つ
     const result = await page.evaluate(() => {
-      app.changeSeats();
-      let printCalled = false;
-      window.print = () => { printCalled = true; }; // 実際の印刷ダイアログは開かせない
-      app.printSeats();
-      return { printCalled: printCalled, printEmptyError: app.printEmptyError };
+      return { printCalled: window.printCalled, printEmptyError: app.printEmptyError, error: app.error };
     });
+    expect(result.error).toBe(false); // フィクスチャは条件を満たせる配置（エラー状態での検証にならないこと）
     expect(result.printCalled).toBe(true);
     expect(result.printEmptyError).toBe(false);
   });
 
   test('印刷レイアウトに席替え後の生徒名・性別色・班の区切りが反映される', async ({ page }) => {
+    await setupFourStudents(page);
     await page.evaluate(() => {
-      app.seatsTable.splice(0, 1, ['A', 'B', '', '', '', '']);
-      app.genderTable.splice(0, 1, ['male', 'female', '', '', '', '']);
-      app.countSeats();
-      return null;
-    });
-    await page.waitForTimeout(150); // watcherでstudentsName/genderArrayが更新されるのを待つ
-
-    const result = await page.evaluate(() => {
       app.changeSeats();
       return null;
     });
@@ -65,6 +75,7 @@ test.describe('印刷', () => {
       const maleSeats = pages[0].querySelectorAll('.print-seat.male-seats').length;
       const femaleSeats = pages[0].querySelectorAll('.print-seat.female-seats').length;
       return {
+        error: app.error,
         pagesCount: pages.length,
         seatsCount: seats.length,
         names: names.sort(),
@@ -76,11 +87,12 @@ test.describe('印刷', () => {
         rows: area.style.getPropertyValue('--print-rows'),
       };
     });
+    expect(printArea.error).toBe(false);
     expect(printArea.pagesCount).toBe(2); // 生徒側から見た図＋教壇側から見た図
     expect(printArea.seatsCount).toBe(36); // 6x6の全座席が描画されている
-    expect(printArea.names).toEqual(['A', 'B']);
-    expect(printArea.maleSeats).toBe(1);
-    expect(printArea.femaleSeats).toBe(1);
+    expect(printArea.names).toEqual(['A', 'B', 'C', 'D']);
+    expect(printArea.maleSeats).toBe(2);
+    expect(printArea.femaleSeats).toBe(2);
     expect(printArea.hasBlackboard).toBe(true);
     expect(printArea.hasCredit).toBe(true);
     expect(printArea.cols).toBe('6');
@@ -116,5 +128,100 @@ test.describe('印刷', () => {
       return children[children.length - 1].classList.contains('print-blackboard');
     });
     expect(blackboardIsLast).toBe(true);
+  });
+
+  test('席替え結果がないとき（復元直後など）は今の座席を印刷できる', async ({ page }) => {
+    // restoreByNameは復元結果をseatsTableへ書き込み、nextSeatsTableは空になる。
+    // その状態でも今の座席がフォールバックとして印刷できることを検証する
+    await setupFourStudents(page);
+    await page.evaluate(() => {
+      window.printCalled = false;
+      window.print = () => { window.printCalled = true; }; // 実際の印刷ダイアログは開かせない
+      app.printSeats();
+      return null;
+    });
+    await page.waitForTimeout(100); // printSeatsは$nextTick経由で印刷するため待つ
+
+    const result = await page.evaluate(() => {
+      const page1 = document.getElementById('print-area').querySelectorAll('.print-page')[0];
+      const names = Array.from(page1.querySelectorAll('.print-seat'))
+        .map(seat => seat.textContent.trim()).filter(Boolean);
+      return {
+        printCalled: window.printCalled,
+        printEmptyError: app.printEmptyError,
+        names: names.sort(),
+        maleSeats: page1.querySelectorAll('.print-seat.male-seats').length,
+        femaleSeats: page1.querySelectorAll('.print-seat.female-seats').length,
+      };
+    });
+    expect(result.printCalled).toBe(true);
+    expect(result.printEmptyError).toBe(false);
+    expect(result.names).toEqual(['A', 'B', 'C', 'D']); // 今の座席の内容が印刷される
+    expect(result.maleSeats).toBe(2);
+    expect(result.femaleSeats).toBe(2);
+  });
+
+  test('ドラッグで調整した入れ替えが、印刷前にnextSeatsTableへ反映される', async ({ page }) => {
+    await setupFourStudents(page);
+    await page.evaluate(() => {
+      app.changeSeats();
+      return null;
+    });
+    await page.waitForTimeout(300); // 再描画とsetSortableJS（setTimeout 100ms）を待つ
+
+    // 同性2人（男子A・D）の位置を特定し、SortableJSのドラッグ入れ替えを再現する。
+    // DOMの入れ替えに加えて、実物のonSort/onEndハンドラを呼んで同期待ちキューも再現する
+    const swapped = await page.evaluate(() => {
+      const findPos = (name) => {
+        for (let r = 0; r < app.nextSeatsTable.length; r++)
+          for (let c = 0; c < app.nextSeatsTable[r].length; c++)
+            if (app.nextSeatsTable[r][c] === name) return [r, c];
+        return null;
+      };
+      const [ar, ac] = findPos('A');
+      const [dr, dc] = findPos('D');
+      const fromSpan = document.getElementById(`nextSeatsRow-${ar}-${ac}`);
+      const toSpan = document.getElementById(`nextSeatsRow-${dr}-${dc}`);
+      // swap:trueと同じDOM入れ替え
+      const fromItem = fromSpan.firstElementChild;
+      const toItem = toSpan.firstElementChild;
+      const ph = document.createComment('ph');
+      fromItem.replaceWith(ph);
+      toItem.replaceWith(fromItem);
+      ph.replaceWith(toItem);
+      // 実物のイベントハンドラを呼ぶ（closure内のisReverseSeats・キューに反映される）
+      const sortable = Sortable.get(fromSpan);
+      sortable.options.onSort();
+      sortable.options.onEnd({ from: fromSpan, to: toSpan });
+      return { a: [ar, ac], d: [dr, dc] };
+    });
+
+    await page.evaluate(() => {
+      window.printCalled = false;
+      window.print = () => { window.printCalled = true; }; // 実際の印刷ダイアログは開かせない
+      app.printSeats();
+      return null;
+    });
+    await page.waitForTimeout(100); // printSeatsは$nextTick経由で印刷するため待つ
+
+    const result = await page.evaluate(({ a, d }) => {
+      const page1 = document.getElementById('print-area').querySelectorAll('.print-page')[0];
+      const grid = Array.from(page1.querySelectorAll('.print-row'))
+        .map(row => Array.from(row.querySelectorAll('.print-seat')).map(seat => seat.textContent.trim()));
+      return {
+        printCalled: window.printCalled,
+        seatAtA: app.nextSeatsTable[a[0]][a[1]],
+        seatAtD: app.nextSeatsTable[d[0]][d[1]],
+        printedAtA: grid[a[0]][a[1]],
+        printedAtD: grid[d[0]][d[1]],
+      };
+    }, swapped);
+
+    expect(result.printCalled).toBe(true);
+    // データも印刷レイアウトも、ドラッグ後の配置（AとDが入れ替わった状態）になっている
+    expect(result.seatAtA).toBe('D');
+    expect(result.seatAtD).toBe('A');
+    expect(result.printedAtA).toBe('D');
+    expect(result.printedAtD).toBe('A');
   });
 });

--- a/tests/print.spec.js
+++ b/tests/print.spec.js
@@ -274,6 +274,36 @@ test.describe('印刷', () => {
     expect(afterSecond.seatAtC).toBe('B');
   });
 
+  test('ドラッグ直後に同じ座席数の保存を復元しても、古いドラッグが復元結果に適用されない', async ({ page }) => {
+    await setupFourStudents(page);
+    await page.evaluate(() => { app.changeSeats(); return null; });
+    await page.waitForTimeout(300);
+
+    // 保存してから、別の配置へドラッグ調整（未反映キューが残る状態を作る）
+    const savedTable = await page.evaluate(() => {
+      app.saveName = 'テスト保存';
+      app.saveWithName(true);
+      return app.nextSeatsTable.map(row => row.slice());
+    });
+    const posA = await findSeatPos(page, 'A');
+    const posD = await findSeatPos(page, 'D');
+    await simulateDragSwap(page, posA, posD);
+
+    // 同じ座席数（6x6）の保存を復元 → 復元前のドラッグは破棄されるべき
+    await page.evaluate(() => {
+      const list = app.getSavedList();
+      app.restoreByName(list[0].id);
+      return null;
+    });
+    await page.waitForTimeout(300);
+
+    const result = await stubAndPrint(page);
+    expect(result.printCalled).toBe(true);
+    // 印刷後も席替え後テーブルは保存時の配置のまま（古いドラッグが混入していない）
+    const restored = await page.evaluate(() => app.nextSeatsTable.map(row => row.slice()));
+    expect(restored).toEqual(savedTable);
+  });
+
   test('ドラッグ直後に座席数を変えても、印刷がクラッシュせずエラー表示になる', async ({ page }) => {
     const pageErrors = [];
     page.on('pageerror', (error) => { pageErrors.push(String(error)); });

--- a/tests/print.spec.js
+++ b/tests/print.spec.js
@@ -18,6 +18,49 @@ async function setupFourStudents(page) {
   await page.waitForTimeout(150); // watcherでstudentsName/genderArrayが更新されるのを待つ
 }
 
+// window.printをスタブしてprintSeats()を呼び、印刷が実行されたかを返す。
+// printSeatsはドラッグ調整の再描画待ち（二段のnextTick）を挟むため、長めに待つ
+async function stubAndPrint(page) {
+  await page.evaluate(() => {
+    window.printCalled = false;
+    window.print = () => { window.printCalled = true; }; // 実際の印刷ダイアログは開かせない
+    app.printSeats();
+    return null;
+  });
+  await page.waitForTimeout(300);
+  return await page.evaluate(() => {
+    return { printCalled: window.printCalled, printEmptyError: app.printEmptyError };
+  });
+}
+
+// SortableJS(swap:true)のドラッグ入れ替えを再現する。
+// DOMの入れ替えに加えて、実物のonSort/onEndハンドラを呼んで同期待ちキューも再現する
+async function simulateDragSwap(page, from, to) {
+  await page.evaluate(({ from, to }) => {
+    const fromSpan = document.getElementById(`nextSeatsRow-${from[0]}-${from[1]}`);
+    const toSpan = document.getElementById(`nextSeatsRow-${to[0]}-${to[1]}`);
+    const fromItem = fromSpan.firstElementChild;
+    const toItem = toSpan.firstElementChild;
+    const ph = document.createComment('ph');
+    fromItem.replaceWith(ph);
+    toItem.replaceWith(fromItem);
+    ph.replaceWith(toItem);
+    const sortable = Sortable.get(fromSpan);
+    sortable.options.onSort();
+    sortable.options.onEnd({ from: fromSpan, to: toSpan });
+    return null;
+  }, { from, to });
+}
+
+async function findSeatPos(page, name) {
+  return await page.evaluate((name) => {
+    for (let r = 0; r < app.nextSeatsTable.length; r++)
+      for (let c = 0; c < app.nextSeatsTable[r].length; c++)
+        if (app.nextSeatsTable[r][c] === name) return [r, c];
+    return null;
+  }, name);
+}
+
 test.describe('印刷', () => {
 
   test.beforeEach(async ({ page }) => {
@@ -25,45 +68,26 @@ test.describe('印刷', () => {
     await page.evaluate(() => { localStorage.clear(); });
   });
 
-  test('座席が空の状態で印刷するとエラーが表示され、window.printは呼ばれない', async ({ page }) => {
-    await page.evaluate(() => {
-      window.printCalled = false;
-      window.print = () => { window.printCalled = true; }; // 実際の印刷ダイアログは開かせない
-      app.printSeats();
-      return null;
-    });
-    await page.waitForTimeout(100); // printSeatsは$nextTick経由で印刷するため待つ
-    const result = await page.evaluate(() => {
-      return { printCalled: window.printCalled, printEmptyError: app.printEmptyError };
-    });
+  test('席替え結果がない状態で印刷するとエラーが表示され、window.printは呼ばれない', async ({ page }) => {
+    const result = await stubAndPrint(page);
     expect(result.printCalled).toBe(false);
     expect(result.printEmptyError).toBe(true);
   });
 
   test('席替え後に印刷するとwindow.printが呼ばれる', async ({ page }) => {
     await setupFourStudents(page);
-    await page.evaluate(() => {
-      app.changeSeats();
-      window.printCalled = false;
-      window.print = () => { window.printCalled = true; }; // 実際の印刷ダイアログは開かせない
-      app.printSeats();
-      return null;
-    });
-    await page.waitForTimeout(100); // printSeatsは$nextTick経由で印刷するため待つ
-    const result = await page.evaluate(() => {
-      return { printCalled: window.printCalled, printEmptyError: app.printEmptyError, error: app.error };
-    });
-    expect(result.error).toBe(false); // フィクスチャは条件を満たせる配置（エラー状態での検証にならないこと）
+    await page.evaluate(() => { app.changeSeats(); return null; });
+    await page.waitForTimeout(150);
+    const result = await stubAndPrint(page);
+    const error = await page.evaluate(() => app.error);
+    expect(error).toBe(false); // フィクスチャは条件を満たせる配置（エラー状態での検証にならないこと）
     expect(result.printCalled).toBe(true);
     expect(result.printEmptyError).toBe(false);
   });
 
-  test('印刷レイアウトに席替え後の生徒名・性別色・班の区切りが反映される', async ({ page }) => {
+  test('印刷レイアウトに席替え後の生徒名・性別色が反映される', async ({ page }) => {
     await setupFourStudents(page);
-    await page.evaluate(() => {
-      app.changeSeats();
-      return null;
-    });
+    await page.evaluate(() => { app.changeSeats(); return null; });
     await page.waitForTimeout(150); // nextSeatsTableの再描画を待つ
 
     // #print-areaは画面上ではdisplay:noneのため、DOMの中身を直接検証する
@@ -72,15 +96,13 @@ test.describe('印刷', () => {
       const pages = Array.from(area.querySelectorAll('.print-page'));
       const seats = Array.from(pages[0].querySelectorAll('.print-seat'));
       const names = seats.map(seat => seat.textContent.trim()).filter(Boolean);
-      const maleSeats = pages[0].querySelectorAll('.print-seat.male-seats').length;
-      const femaleSeats = pages[0].querySelectorAll('.print-seat.female-seats').length;
       return {
         error: app.error,
         pagesCount: pages.length,
         seatsCount: seats.length,
         names: names.sort(),
-        maleSeats: maleSeats,
-        femaleSeats: femaleSeats,
+        maleSeats: pages[0].querySelectorAll('.print-seat.male-seats').length,
+        femaleSeats: pages[0].querySelectorAll('.print-seat.female-seats').length,
         hasBlackboard: pages[0].querySelector('.print-blackboard') !== null,
         hasCredit: area.querySelector('.print-credit') !== null,
         cols: area.style.getPropertyValue('--print-cols'),
@@ -97,6 +119,46 @@ test.describe('印刷', () => {
     expect(printArea.hasCredit).toBe(true);
     expect(printArea.cols).toBe('6');
     expect(printArea.rows).toBe('6');
+  });
+
+  test('班の区切りと班長の星が両ページに正しく反映される', async ({ page }) => {
+    await setupFourStudents(page);
+    await page.evaluate(() => {
+      app.leaderConditions = ['A', ''];
+      return null;
+    });
+    await page.waitForTimeout(100);
+    await page.evaluate(() => { app.changeSeats(); return null; });
+    await page.waitForTimeout(150);
+
+    // 6x6・班2x3のとき：どの行も2列目・4列目の後ろに班の区切り（列インデックス1と3）、
+    // 3行目の後ろに1つだけ行の区切りが入る。180度回転した2ページ目でも同じ位置になるはず
+    const result = await page.evaluate(() => {
+      const pages = document.getElementById('print-area').querySelectorAll('.print-page');
+      const readGaps = (pageEl) => {
+        const rows = Array.from(pageEl.querySelectorAll('.print-row'));
+        const gapColsPerRow = rows.map(row =>
+          Array.from(row.querySelectorAll('.print-seat'))
+            .map((seat, i) => seat.classList.contains('print-group-gap-right') ? i : -1)
+            .filter(i => i !== -1)
+        );
+        return {
+          gapColsPerRow: gapColsPerRow,
+          gapBottomCount: pageEl.querySelectorAll('.print-group-gap-bottom').length,
+          leaderStars: pageEl.querySelectorAll('.print-leader-star').length,
+        };
+      };
+      return { page1: readGaps(pages[0]), page2: readGaps(pages[1]) };
+    });
+
+    for (const pageResult of [result.page1, result.page2]) {
+      expect(pageResult.gapColsPerRow).toHaveLength(6);
+      for (const gapCols of pageResult.gapColsPerRow) {
+        expect(gapCols).toEqual([1, 3]); // 2列目・4列目の後ろ（最後の列には付かない）
+      }
+      expect(pageResult.gapBottomCount).toBe(1); // 3行目の後ろのみ
+      expect(pageResult.leaderStars).toBe(1); // 班長Aの星が1つ
+    }
   });
 
   test('2ページ目（教壇側から見た図）は1ページ目を180度回転した配置になる', async ({ page }) => {
@@ -130,98 +192,107 @@ test.describe('印刷', () => {
     expect(blackboardIsLast).toBe(true);
   });
 
-  test('席替え結果がないとき（復元直後など）は今の座席を印刷できる', async ({ page }) => {
-    // restoreByNameは復元結果をseatsTableへ書き込み、nextSeatsTableは空になる。
-    // その状態でも今の座席がフォールバックとして印刷できることを検証する
+  test('保存した結果を復元すると席替え後テーブルに入り、そのまま印刷できる', async ({ page }) => {
     await setupFourStudents(page);
+    await page.evaluate(() => { app.changeSeats(); return null; });
+    await page.waitForTimeout(150);
+
+    // 保存してから、席替え後テーブルを空にして（別の作業をした状態を再現）復元する
+    const savedTable = await page.evaluate(() => {
+      app.saveName = 'テスト保存';
+      app.saveWithName(true);
+      const saved = app.nextSeatsTable.map(row => row.slice());
+      app.makeNextSeatsTable(); // 席替え後テーブルを空にする
+      return saved;
+    });
+    await page.waitForTimeout(100);
     await page.evaluate(() => {
-      window.printCalled = false;
-      window.print = () => { window.printCalled = true; }; // 実際の印刷ダイアログは開かせない
-      app.printSeats();
+      const list = app.getSavedList();
+      app.restoreByName(list[0].id);
       return null;
     });
-    await page.waitForTimeout(100); // printSeatsは$nextTick経由で印刷するため待つ
+    await page.waitForTimeout(300); // watcherとnextTickでの席替え後テーブル反映を待つ
 
-    const result = await page.evaluate(() => {
-      const page1 = document.getElementById('print-area').querySelectorAll('.print-page')[0];
-      const names = Array.from(page1.querySelectorAll('.print-seat'))
-        .map(seat => seat.textContent.trim()).filter(Boolean);
-      return {
-        printCalled: window.printCalled,
-        printEmptyError: app.printEmptyError,
-        names: names.sort(),
-        maleSeats: page1.querySelectorAll('.print-seat.male-seats').length,
-        femaleSeats: page1.querySelectorAll('.print-seat.female-seats').length,
-      };
-    });
+    const restored = await page.evaluate(() => app.nextSeatsTable.map(row => row.slice()));
+    expect(restored).toEqual(savedTable); // 復元結果が席替え後テーブルに入っている
+
+    const result = await stubAndPrint(page);
     expect(result.printCalled).toBe(true);
     expect(result.printEmptyError).toBe(false);
-    expect(result.names).toEqual(['A', 'B', 'C', 'D']); // 今の座席の内容が印刷される
-    expect(result.maleSeats).toBe(2);
-    expect(result.femaleSeats).toBe(2);
   });
 
-  test('ドラッグで調整した入れ替えが、印刷前にnextSeatsTableへ反映される', async ({ page }) => {
+  test('ドラッグの入れ替えが印刷前に反映され、印刷後も再度ドラッグできる', async ({ page }) => {
     await setupFourStudents(page);
-    await page.evaluate(() => {
-      app.changeSeats();
-      return null;
-    });
+    await page.evaluate(() => { app.changeSeats(); return null; });
     await page.waitForTimeout(300); // 再描画とsetSortableJS（setTimeout 100ms）を待つ
 
-    // 同性2人（男子A・D）の位置を特定し、SortableJSのドラッグ入れ替えを再現する。
-    // DOMの入れ替えに加えて、実物のonSort/onEndハンドラを呼んで同期待ちキューも再現する
-    const swapped = await page.evaluate(() => {
-      const findPos = (name) => {
-        for (let r = 0; r < app.nextSeatsTable.length; r++)
-          for (let c = 0; c < app.nextSeatsTable[r].length; c++)
-            if (app.nextSeatsTable[r][c] === name) return [r, c];
-        return null;
-      };
-      const [ar, ac] = findPos('A');
-      const [dr, dc] = findPos('D');
-      const fromSpan = document.getElementById(`nextSeatsRow-${ar}-${ac}`);
-      const toSpan = document.getElementById(`nextSeatsRow-${dr}-${dc}`);
-      // swap:trueと同じDOM入れ替え
-      const fromItem = fromSpan.firstElementChild;
-      const toItem = toSpan.firstElementChild;
-      const ph = document.createComment('ph');
-      fromItem.replaceWith(ph);
-      toItem.replaceWith(fromItem);
-      ph.replaceWith(toItem);
-      // 実物のイベントハンドラを呼ぶ（closure内のisReverseSeats・キューに反映される）
-      const sortable = Sortable.get(fromSpan);
-      sortable.options.onSort();
-      sortable.options.onEnd({ from: fromSpan, to: toSpan });
-      return { a: [ar, ac], d: [dr, dc] };
-    });
+    // 男子A・Dの位置を特定してドラッグ入れ替え
+    const posA = await findSeatPos(page, 'A');
+    const posD = await findSeatPos(page, 'D');
+    await simulateDragSwap(page, posA, posD);
 
-    await page.evaluate(() => {
-      window.printCalled = false;
-      window.print = () => { window.printCalled = true; }; // 実際の印刷ダイアログは開かせない
-      app.printSeats();
-      return null;
-    });
-    await page.waitForTimeout(100); // printSeatsは$nextTick経由で印刷するため待つ
+    const result1 = await stubAndPrint(page);
+    expect(result1.printCalled).toBe(true);
 
-    const result = await page.evaluate(({ a, d }) => {
+    // データも印刷レイアウトも、ドラッグ後の配置（AとDが入れ替わった状態）になっている
+    const afterFirst = await page.evaluate(({ posA, posD }) => {
       const page1 = document.getElementById('print-area').querySelectorAll('.print-page')[0];
       const grid = Array.from(page1.querySelectorAll('.print-row'))
         .map(row => Array.from(row.querySelectorAll('.print-seat')).map(seat => seat.textContent.trim()));
       return {
-        printCalled: window.printCalled,
-        seatAtA: app.nextSeatsTable[a[0]][a[1]],
-        seatAtD: app.nextSeatsTable[d[0]][d[1]],
-        printedAtA: grid[a[0]][a[1]],
-        printedAtD: grid[d[0]][d[1]],
+        seatAtA: app.nextSeatsTable[posA[0]][posA[1]],
+        seatAtD: app.nextSeatsTable[posD[0]][posD[1]],
+        printedAtA: grid[posA[0]][posA[1]],
+        printedAtD: grid[posD[0]][posD[1]],
       };
-    }, swapped);
+    }, { posA, posD });
+    expect(afterFirst.seatAtA).toBe('D');
+    expect(afterFirst.seatAtD).toBe('A');
+    expect(afterFirst.printedAtA).toBe('D');
+    expect(afterFirst.printedAtD).toBe('A');
 
-    expect(result.printCalled).toBe(true);
-    // データも印刷レイアウトも、ドラッグ後の配置（AとDが入れ替わった状態）になっている
-    expect(result.seatAtA).toBe('D');
-    expect(result.seatAtD).toBe('A');
-    expect(result.printedAtA).toBe('D');
-    expect(result.printedAtD).toBe('A');
+    // 印刷時の再描画後もSortableJSが再セットされ、続けてドラッグ調整できる
+    const rebound = await page.evaluate((pos) => {
+      const span = document.getElementById(`nextSeatsRow-${pos[0]}-${pos[1]}`);
+      return Sortable.get(span) !== undefined;
+    }, posA);
+    expect(rebound).toBe(true);
+
+    // 2回目のドラッグ（女子B・C）も印刷に反映される
+    const posB = await findSeatPos(page, 'B');
+    const posC = await findSeatPos(page, 'C');
+    await simulateDragSwap(page, posB, posC);
+    const result2 = await stubAndPrint(page);
+    expect(result2.printCalled).toBe(true);
+    const afterSecond = await page.evaluate(({ posB, posC }) => {
+      return {
+        seatAtB: app.nextSeatsTable[posB[0]][posB[1]],
+        seatAtC: app.nextSeatsTable[posC[0]][posC[1]],
+      };
+    }, { posB, posC });
+    expect(afterSecond.seatAtB).toBe('C');
+    expect(afterSecond.seatAtC).toBe('B');
+  });
+
+  test('ドラッグ直後に座席数を変えても、印刷がクラッシュせずエラー表示になる', async ({ page }) => {
+    const pageErrors = [];
+    page.on('pageerror', (error) => { pageErrors.push(String(error)); });
+
+    await setupFourStudents(page);
+    await page.evaluate(() => { app.changeSeats(); return null; });
+    await page.waitForTimeout(300);
+
+    // ドラッグしてから座席テーブルを小さく作り直す（未反映キューの座標が範囲外になる状況）
+    const posA = await findSeatPos(page, 'A');
+    const posD = await findSeatPos(page, 'D');
+    await simulateDragSwap(page, posA, posD);
+    await page.evaluate(() => { app.seatsSizeY = 4; return null; });
+    await page.waitForTimeout(300);
+
+    // 席替え後テーブルは空になっているのでエラーダイアログが出る（クラッシュしない）
+    const result = await stubAndPrint(page);
+    expect(pageErrors).toEqual([]);
+    expect(result.printCalled).toBe(false);
+    expect(result.printEmptyError).toBe(true);
   });
 });

--- a/tests/print.spec.js
+++ b/tests/print.spec.js
@@ -1,0 +1,120 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const INDEX_HTML = `file://${path.resolve(__dirname, '../index.html')}`;
+
+test.describe('印刷', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(INDEX_HTML, { waitUntil: 'networkidle' });
+    await page.evaluate(() => { localStorage.clear(); });
+  });
+
+  test('席替え結果がない状態で印刷するとエラーが表示され、window.printは呼ばれない', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      let printCalled = false;
+      window.print = () => { printCalled = true; }; // 実際の印刷ダイアログは開かせない
+      app.printSeats();
+      return { printCalled: printCalled, printEmptyError: app.printEmptyError };
+    });
+    expect(result.printCalled).toBe(false);
+    expect(result.printEmptyError).toBe(true);
+  });
+
+  test('席替え後に印刷するとwindow.printが呼ばれる', async ({ page }) => {
+    await page.evaluate(() => {
+      app.seatsTable.splice(0, 1, ['A', 'B', '', '', '', '']);
+      app.genderTable.splice(0, 1, ['male', 'female', '', '', '', '']);
+      app.countSeats();
+      return null;
+    });
+    await page.waitForTimeout(150); // watcherでstudentsName/genderArrayが更新されるのを待つ
+
+    const result = await page.evaluate(() => {
+      app.changeSeats();
+      let printCalled = false;
+      window.print = () => { printCalled = true; }; // 実際の印刷ダイアログは開かせない
+      app.printSeats();
+      return { printCalled: printCalled, printEmptyError: app.printEmptyError };
+    });
+    expect(result.printCalled).toBe(true);
+    expect(result.printEmptyError).toBe(false);
+  });
+
+  test('印刷レイアウトに席替え後の生徒名・性別色・班の区切りが反映される', async ({ page }) => {
+    await page.evaluate(() => {
+      app.seatsTable.splice(0, 1, ['A', 'B', '', '', '', '']);
+      app.genderTable.splice(0, 1, ['male', 'female', '', '', '', '']);
+      app.countSeats();
+      return null;
+    });
+    await page.waitForTimeout(150); // watcherでstudentsName/genderArrayが更新されるのを待つ
+
+    const result = await page.evaluate(() => {
+      app.changeSeats();
+      return null;
+    });
+    await page.waitForTimeout(150); // nextSeatsTableの再描画を待つ
+
+    // #print-areaは画面上ではdisplay:noneのため、DOMの中身を直接検証する
+    const printArea = await page.evaluate(() => {
+      const area = document.getElementById('print-area');
+      const pages = Array.from(area.querySelectorAll('.print-page'));
+      const seats = Array.from(pages[0].querySelectorAll('.print-seat'));
+      const names = seats.map(seat => seat.textContent.trim()).filter(Boolean);
+      const maleSeats = pages[0].querySelectorAll('.print-seat.male-seats').length;
+      const femaleSeats = pages[0].querySelectorAll('.print-seat.female-seats').length;
+      return {
+        pagesCount: pages.length,
+        seatsCount: seats.length,
+        names: names.sort(),
+        maleSeats: maleSeats,
+        femaleSeats: femaleSeats,
+        hasBlackboard: pages[0].querySelector('.print-blackboard') !== null,
+        hasCredit: area.querySelector('.print-credit') !== null,
+        cols: area.style.getPropertyValue('--print-cols'),
+        rows: area.style.getPropertyValue('--print-rows'),
+      };
+    });
+    expect(printArea.pagesCount).toBe(2); // 生徒側から見た図＋教壇側から見た図
+    expect(printArea.seatsCount).toBe(36); // 6x6の全座席が描画されている
+    expect(printArea.names).toEqual(['A', 'B']);
+    expect(printArea.maleSeats).toBe(1);
+    expect(printArea.femaleSeats).toBe(1);
+    expect(printArea.hasBlackboard).toBe(true);
+    expect(printArea.hasCredit).toBe(true);
+    expect(printArea.cols).toBe('6');
+    expect(printArea.rows).toBe('6');
+  });
+
+  test('2ページ目（教壇側から見た図）は1ページ目を180度回転した配置になる', async ({ page }) => {
+    // nextSeatsTableへ直接、位置が特定できる配置を書き込んで検証する
+    await page.evaluate(() => {
+      app.nextSeatsTable.splice(0, 1, ['A', 'B', '', '', '', 'C']);
+      app.nextSeatsTable.splice(5, 1, ['D', '', '', '', '', 'E']);
+      return null;
+    });
+    await page.waitForTimeout(150); // 再描画を待つ
+
+    const result = await page.evaluate(() => {
+      const pages = document.getElementById('print-area').querySelectorAll('.print-page');
+      const readGrid = (pageEl) => Array.from(pageEl.querySelectorAll('.print-row'))
+        .map(row => Array.from(row.querySelectorAll('.print-seat')).map(seat => seat.textContent.trim()));
+      return { student: readGrid(pages[0]), teacher: readGrid(pages[1]) };
+    });
+
+    // 1ページ目は入力どおり
+    expect(result.student[0]).toEqual(['A', 'B', '', '', '', 'C']);
+    expect(result.student[5]).toEqual(['D', '', '', '', '', 'E']);
+    // 2ページ目は行・列とも逆順（180度回転）
+    expect(result.teacher[0]).toEqual(['E', '', '', '', '', 'D']);
+    expect(result.teacher[5]).toEqual(['C', '', '', '', 'B', 'A']);
+    // 2ページ目では黒板が座席より後（下端）に表示される
+    const blackboardIsLast = await page.evaluate(() => {
+      const page2 = document.getElementById('print-area').querySelectorAll('.print-page')[1];
+      const children = Array.from(page2.children);
+      return children[children.length - 1].classList.contains('print-blackboard');
+    });
+    expect(blackboardIsLast).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要
席替え後の座席表をブラウザの印刷機能から印刷（またはPDF保存）できるようにしました。

## 変更内容

### 印刷ボタン
- 「結果を保存」ボタンの右側に同デザインの「印刷」ボタンを追加（PC・スマホ・タブレット）
- 席替え結果がない状態で押した場合はエラーダイアログを表示

### 印刷レイアウト（A4横向き・2ページ構成）
- **1ページ目**: 生徒側から見た座席表（黒板が上端）
- **2ページ目**: 教壇側から見た座席表（1ページ目を180度回転、黒板が下端）
- 性別の座席色・班の区切り・班長の星（★）を印刷にも反映
- `@page { margin: 0 }` でブラウザが印字するヘッダー・フッター（ページタイトル・URL・日付）を抑止し、代わりに右下へ「©席替えメーカー」を小さく表示
- 列数・行数が多い場合も1ページに収まるよう座席サイズを自動縮小
- 画面には一切表示されない印刷専用DOM（`#print-area`）のため、既存レイアウトへの影響なし

### スマホのボタン縮小
- 一括入力・結果を保存・印刷ボタンをサイドバー下部のボタンと同じ大きさ（高さ34px・文字13px）に統一し、窮屈さを解消

### 告知
- 更新情報に追記（2026.07.21）
- 新機能のお知らせモーダルに印刷機能を追加し、キーをv4に更新（既存ユーザーにも1回表示）

## テスト
- 印刷機能のPlaywrightテストを新規追加（`tests/print.spec.js`・4件）
  - 結果なしでの印刷 → エラー表示・window.print未呼び出し
  - 結果ありでの印刷 → window.print呼び出し
  - 印刷レイアウトへの生徒名・性別色・2ページ構成の反映
  - 2ページ目の180度回転配置と黒板位置
- 全53件パス
- PC/スマホ/タブレットのスクリーンショットとA4横PDF出力で見た目を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)